### PR TITLE
seed objects in dev/test backend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,12 @@ services:
     labels:
       - "traefik.port=5000"
       - "traefik.frontend.rule=PathPrefix: /spark"
+    volumes:
+      - "./mocks/config/seed_objects.json:/app/seed_objects.json"
     command:
       - "--simulation"
+      - "--seed-profiles=0"
+      - "--seed-objects=seed_objects.json"
 
   datastore:
     image: brewblox/brewblox-datastore:develop

--- a/mocks/config/seed_objects.json
+++ b/mocks/config/seed_objects.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "setpoint-1",
+    "profiles": [
+      0
+    ],
+    "type": "SetPointSimple",
+    "data": {
+      "setting": 21
+    }
+  },
+  {
+    "id": "setpoint-2",
+    "profiles": [
+      0
+    ],
+    "type": "SetPointSimple",
+    "data": {
+      "setting": 1
+    }
+  },
+  {
+    "id": "sensor-1",
+    "profiles": [
+      0
+    ],
+    "type": "OneWireTempSensor",
+    "data": {
+      "settings": {
+        "address": "DEADBEEF",
+        "offset": 0
+      },
+      "state": {
+        "value[celsius]": 20.89789201,
+        "connected": true
+      }
+    }
+  },
+  {
+    "id": "sensor-setpoint-pair-1",
+    "profiles": [
+      0
+    ],
+    "type": "SensorSetPointPair",
+    "data": {
+      "sensor<>": "sensor-1",
+      "setpoint<>": "setpoint-1"
+    }
+  },
+  {
+    "id": "PID-1",
+    "profiles": [
+      0
+    ],
+    "type": "Pid",
+    "data": {
+      "settings": {
+        "kp": 10,
+        "ti": 600,
+        "td": 60
+      },
+      "links": {
+        "input<>": "sensor-setpoint-pair-1"
+      },
+      "filtering": {
+        "input": 3,
+        "derivative": 4
+      },
+      "state": {
+        "inputValue": 21.0859,
+        "inputSetting": 20,
+        "outputValue": 45.6758,
+        "p": 10.7813,
+        "i": 34.8164,
+        "d": 0.0781,
+        "derivative": 0.001301666667,
+        "integral": 20889.84,
+        "error": -1.0781
+      }
+    }
+  }
+]

--- a/src/brewblox.d.ts
+++ b/src/brewblox.d.ts
@@ -15,7 +15,7 @@ interface PluginArguments {
 // Widget types
 type WidgetType =
   'Metrics' |
-  'PID' |
+  'Pid' |
   'OneWireTempSensor' |
   'SetPointSimple' |
   'SensorSetPointPair';

--- a/src/components/blocks/SensorSetPointPair/Create.ts
+++ b/src/components/blocks/SensorSetPointPair/Create.ts
@@ -89,10 +89,8 @@ class SensorSetPointPair extends Vue {
 
       const block = await createSensorSetPointPair(this.$store, {
         serviceId: this.service.id,
-        links: {
-          sensor: this.sensorInput.id,
-          setpoint: this.setpointInput.id,
-        },
+        sensor: this.sensorInput.id,
+        setpoint: this.setpointInput.id,
       });
 
       this.creating = false;

--- a/src/components/blocks/SensorSetPointPair/SensorSetPointPair.ts
+++ b/src/components/blocks/SensorSetPointPair/SensorSetPointPair.ts
@@ -31,21 +31,17 @@ export default class SensorSetPointPair extends BlockComponent {
     return getById(this.$store, this.$props.id);
   }
 
-  get links() {
-    return this.blockData.links;
-  }
-
   get sensor() {
     return getOneWireTempSensorById(
       this.$store,
-      `${this.blockData.serviceId}/${this.links.sensor}`,
+      `${this.blockData.serviceId}/${this.blockData.sensor}`,
     );
   }
 
   get setpoint() {
     return getSetPointSimpleById(
       this.$store,
-      `${this.blockData.serviceId}/${this.links.setpoint}`,
+      `${this.blockData.serviceId}/${this.blockData.setpoint}`,
     );
   }
 
@@ -81,10 +77,8 @@ export default class SensorSetPointPair extends BlockComponent {
 
   save() {
     persist(this.$store, {
-      links: {
-        sensor: this.sensorInput,
-        setpoint: this.setpointInput,
-      },
+      sensor: this.sensorInput,
+      setpoint: this.setpointInput,
       id: this.blockData.id,
       serviceId: this.blockData.serviceId,
     });

--- a/src/components/blocks/SetPointSimple/SetPointSimple.ts
+++ b/src/components/blocks/SetPointSimple/SetPointSimple.ts
@@ -22,25 +22,23 @@ export default class SetPointSimple extends BlockComponent {
     return getById(this.$store, this.$props.id);
   }
 
-  get settings() {
-    return this.blockData.settings;
+  get setting() {
+    return this.blockData.setting;
   }
 
   get changed() {
-    return this.settings.value !== this.valueInput;
+    return this.setting !== this.valueInput;
   }
 
   mounted() {
-    this.valueInput = this.settings.value;
+    this.valueInput = this.setting;
   }
 
   save() {
     persist(this.$store, {
       id: this.blockData.id,
       serviceId: this.blockData.serviceId,
-      settings: {
-        value: this.valueInput,
-      },
+      setting: this.valueInput,
     });
   }
 }

--- a/src/components/widget-modal/widget-types.ts
+++ b/src/components/widget-modal/widget-types.ts
@@ -10,7 +10,7 @@ import { deviceServices } from '@/store/services/getters';
 
 export const widgetTypes: { [key in WidgetType]: string } = {
   Metrics: 'Metrics',
-  PID: 'PID',
+  Pid: 'PID',
   OneWireTempSensor: 'Temperature Sensor',
   SetPointSimple: 'SetPoint',
   SensorSetPointPair: 'Sensor SetPoint Pair',
@@ -30,7 +30,7 @@ export function blocksByWidgetType(store: RootStore, type: WidgetType): Block[] 
   const services = deviceServices(store);
 
   switch (type) {
-    case 'PID':
+    case 'Pid':
       return getBlocksFromServices(services, store, getAllPIDs);
     case 'OneWireTempSensor':
       return getBlocksFromServices(services, store, getAllOneWireTempSensors);
@@ -45,7 +45,7 @@ export function blocksByWidgetType(store: RootStore, type: WidgetType): Block[] 
 
 export const widgetComponents: { [name in WidgetType]: () => Promise<any> } = {
   Metrics: () => import('@/components/widgets/Metrics/Create.vue'),
-  PID: () => import('@/components/blocks/PID/Create.vue'),
+  Pid: () => import('@/components/blocks/PID/Create.vue'),
   OneWireTempSensor: () => import('@/components/blocks/OneWireTempSensor/Create.vue'),
   SetPointSimple: () => import('@/components/blocks/SetPointSimple/Create.vue'),
   SensorSetPointPair: () => import('@/components/blocks/SensorSetPointPair/Create.vue'),

--- a/src/components/widgets/SensorSetPointPair/SensorSetPointPair.ts
+++ b/src/components/widgets/SensorSetPointPair/SensorSetPointPair.ts
@@ -32,7 +32,7 @@ export default class SensorSetPointPairWidget extends mixins(BlockWidget) {
   }
 
   get setpointChanged() {
-    return this.setPoint.settings.value !== this.inputs.setpoint;
+    return this.setPoint.setting !== this.inputs.setpoint;
   }
 
   save() {

--- a/src/components/widgets/SensorSetPointPair/SensorSetPointPair.ts
+++ b/src/components/widgets/SensorSetPointPair/SensorSetPointPair.ts
@@ -20,15 +20,15 @@ export default class SensorSetPointPairWidget extends mixins(BlockWidget) {
   }
 
   get sensor(): OneWireTempSensorBlock {
-    const { links, serviceId } = this.blockData;
+    const { sensor, serviceId } = this.blockData;
 
-    return getSensorById(this.$store, `${serviceId}/${links.sensor}`);
+    return getSensorById(this.$store, `${serviceId}/${sensor}`);
   }
 
   get setPoint(): SetPointSimpleBlock {
-    const { links, serviceId } = this.blockData;
+    const { setpoint, serviceId } = this.blockData;
 
-    return getSetPointById(this.$store, `${serviceId}/${links.setpoint}`);
+    return getSetPointById(this.$store, `${serviceId}/${setpoint}`);
   }
 
   get setpointChanged() {

--- a/src/components/widgets/componentByType.ts
+++ b/src/components/widgets/componentByType.ts
@@ -7,7 +7,7 @@ import Placeholder from './Placeholder.vue';
 
 function componentByType(type: WidgetType) {
   switch (type) {
-    case 'PID':
+    case 'Pid':
       return PID;
     case 'Metrics':
       return Metrics;

--- a/src/core/units/Link.ts
+++ b/src/core/units/Link.ts
@@ -1,0 +1,11 @@
+export default class Link {
+  id: string;
+
+  constructor(id: string) {
+    this.id = id;
+  }
+
+  toJSON(): string {
+    return this.id;
+  }
+}

--- a/src/core/units/Link.ts
+++ b/src/core/units/Link.ts
@@ -5,6 +5,10 @@ export default class Link {
     this.id = id;
   }
 
+  toString(): string {
+    return this.id;
+  }
+
   toJSON(): string {
     return this.id;
   }

--- a/src/core/units/parseObject.test.ts
+++ b/src/core/units/parseObject.test.ts
@@ -136,4 +136,22 @@ describe('serialize', () => {
 
     expect(serialize(input)).toEqual(output);
   });
+
+  it('Converts link properties for API saving', () => {
+    const input = {
+      sensor: new Link('sensor-1'),
+      deeper: {
+        sensor: new Link('sensor-2'),
+      },
+    };
+
+    const output = {
+      'sensor<>': 'sensor-1',
+      deeper: {
+        'sensor<>': 'sensor-2',
+      },
+    };
+
+    expect(serialize(input)).toEqual(output);
+  });
 });

--- a/src/core/units/parseObject.test.ts
+++ b/src/core/units/parseObject.test.ts
@@ -1,4 +1,5 @@
 import Unit from './Unit';
+import Link from './Link';
 import { Celsius, Fahrenheit } from './Temperature';
 
 import { deserialize, serialize } from './parseObject';
@@ -72,6 +73,22 @@ describe('deserialize', () => {
     expect(output[0].convert).toBeInstanceOf(Celsius);
     expect(output[1]).toBe(25);
     expect(output[2]).toBe('do not touch');
+  });
+
+  it('Should recognise properties structured as links', () => {
+    const input = {
+      test: 'Do not touch',
+      something: 1,
+      'sensor<>': 'some-sensor-id',
+      'sensors<>': ['sensor-1', 'sensor-2'],
+    };
+
+    const output = deserialize(input);
+
+    expect(output.test).toBe('Do not touch');
+    expect(output.something).not.toBeInstanceOf(Link);
+    expect(output.sensor).toBeInstanceOf(Link);
+    expect(output.sensors[0]).toBeInstanceOf(Link);
   });
 });
 

--- a/src/core/units/parseObject.ts
+++ b/src/core/units/parseObject.ts
@@ -25,6 +25,13 @@ function propertyNameWithUnit(key: string, inputObject: any): string {
     return `${key}[${input.unit}]`;
   }
 
+  if (
+    (Array.isArray(input) && input[0] instanceof Link) ||
+    input instanceof Link
+  ) {
+    return `${key}<>`;
+  }
+
   return key;
 }
 
@@ -75,6 +82,10 @@ export function deserialize(input: any, prevKey: string = ''): any {
 function serializeProperty(key: string, inputObject: any, input = inputObject[key]): any {
   if (input instanceof Unit) {
     return input.value;
+  }
+
+  if (input instanceof Link) {
+    return input.id;
   }
 
   if (typeof input === 'object') {

--- a/src/core/units/parseObject.ts
+++ b/src/core/units/parseObject.ts
@@ -1,7 +1,9 @@
 import Unit from './Unit';
+import Link from './Link';
 import valueToUnit from './convertUnit';
 
-const extractUnit = /^([a-zA-Z0-9_.\-[\]]+)\[([a-zA-Z]+)]$/;
+// const extractUnit = /^([a-zA-Z0-9_.\-[\]]+)(\[([a-zA-Z_]+)]|<>)$/;
+const extractUnit = /^([^[<]+)([[<])([^\]>]*)[\]>]$/;
 
 export function propertyNameWithoutUnit(name: string): string {
   const matched = name.match(extractUnit);
@@ -26,12 +28,16 @@ function propertyNameWithUnit(key: string, inputObject: any): string {
   return key;
 }
 
-export function convertToUnit(key: string, value: any): Unit {
+export function convertToUnit(key: string, value: any): Unit | Link {
   const matched = key.match(extractUnit);
 
   if (matched) {
     try {
-      return valueToUnit(value, matched[2]);
+      if (matched[2] === '<') {
+        return new Link(value);
+      }
+
+      return valueToUnit(value, matched[3]);
     } catch (e) {
       return value;
     }

--- a/src/store/blocks/PID/PID.d.ts
+++ b/src/store/blocks/PID/PID.d.ts
@@ -49,5 +49,5 @@ export interface PIDStateUpdate extends BlockBase {
 }
 
 export interface PIDBlock extends PID {
-  type: 'PID';
+  type: 'Pid';
 }

--- a/src/store/blocks/PID/actions.ts
+++ b/src/store/blocks/PID/actions.ts
@@ -25,7 +25,7 @@ export const addPID = (
       links,
       filtering,
       state,
-      type: 'PID',
+      type: 'Pid',
     },
   );
 };

--- a/src/store/blocks/PID/getters.ts
+++ b/src/store/blocks/PID/getters.ts
@@ -6,5 +6,5 @@ import { RootStore } from '../../state';
 
 export function getAll(store: RootStore, serviceId: string): PIDBlock[] {
   return allBlockFromService(store, serviceId)
-    .filter(block => block.type === 'PID') as PIDBlock[];
+    .filter(block => block.type === 'Pid') as PIDBlock[];
 }

--- a/src/store/blocks/SensorSetPointPair/SensorSetPointPair.d.ts
+++ b/src/store/blocks/SensorSetPointPair/SensorSetPointPair.d.ts
@@ -2,17 +2,13 @@ import { BlockBase } from '../state';
 import { NewBlockBase } from '@/store/blocks/state';
 
 export interface SensorSetPointPair extends BlockBase {
-  links: {
-    sensor: string,
-    setpoint: string,
-  };
+  sensor: string;
+  setpoint: string;
 }
 
 export interface SensorSetPointPairPersisted {
-  links: {
-    sensor: string,
-    setpoint: string,
-  };
+  sensor: string;
+  setpoint: string;
 }
 
 export interface SensorSetPointPairCreateNew extends NewBlockBase, SensorSetPointPairPersisted {}

--- a/src/store/blocks/SensorSetPointPair/actions.ts
+++ b/src/store/blocks/SensorSetPointPair/actions.ts
@@ -14,12 +14,21 @@ export const createSensorSetPointPair =
     });
 
 export const addSensorSetPointPair =
-  (context: BlocksContext, { id, serviceId, links }: SensorSetPointPair) => addBlock(
+  (
+    context: BlocksContext,
+    {
+      id,
+      serviceId,
+      sensor,
+      setpoint,
+    }: SensorSetPointPair,
+  ) => addBlock(
     context,
     {
       id,
       serviceId,
-      links,
+      sensor,
+      setpoint,
       type: 'SensorSetPointPair',
     },
   );

--- a/src/store/blocks/SetPointSimple/SetPointSimple.d.ts
+++ b/src/store/blocks/SetPointSimple/SetPointSimple.d.ts
@@ -1,9 +1,7 @@
 import { BlockBase } from '../state';
 
 export interface SetPointSimple extends BlockBase {
-  settings: {
-    value: number,
-  };
+  setting: number;
 }
 
 export interface SetPointSimpleBlock extends SetPointSimple {

--- a/src/store/blocks/SetPointSimple/actions.ts
+++ b/src/store/blocks/SetPointSimple/actions.ts
@@ -7,14 +7,14 @@ import { BlocksContext } from '../state';
 
 export const addSetPoint = (
   context: BlocksContext,
-  { id, serviceId, settings }: SetPointSimple,
+  { id, serviceId, setting }: SetPointSimple,
 ) => {
   addBlock(
     context,
     {
       id,
       serviceId,
-      settings,
+      setting,
       type: 'SetPointSimple',
     },
   );

--- a/src/store/blocks/add-block.ts
+++ b/src/store/blocks/add-block.ts
@@ -16,10 +16,10 @@ export default function addBlock(context: BlocksContext, block: Block, metrics: 
     case 'SetPointSimple':
       addSetPoint(context, block);
       break;
-    case 'PID':
+    case 'Pid':
       addPID(context, block);
       break;
     default:
-      throw new Error('Invalid block type');
+      throw new Error(`Invalid block type "${(block as Block).type}"`);
   }
 }


### PR DESCRIPTION
See brewblox/brewblox-devcon-spark#77 for backend implementation.

Changes:
* Added a `seed_objects.json` file, and configured devcon-spark to load those blocks on startup.
* Updated objects in `seed_objects.json` to conform to current proto file definitions.

Todo:
* Update Vue data classes to conform to proto data layout.

Notes:
* As links are now resolved by the service, objects must be created in order, and can't link to objects that do not yet exist on the backend.