### PR TITLE
Display wait time that counts down in mutex

### DIFF
--- a/src/plugins/spark/features/Mutex/MutexWidget.vue
+++ b/src/plugins/spark/features/Mutex/MutexWidget.vue
@@ -37,14 +37,6 @@ export default class MutexWidget extends BlockWidget {
     <q-card-separator/>
     <q-card-main class="column widget-body">
       <div class="full-width">
-        <q-field label="Idle time before allowing a different actuator">
-          <TimeUnitPopupEdit
-            :field="block.data.differentActuatorWait"
-            :change="callAndSaveBlock(v => block.data.differentActuatorWait = v)"
-            type="number"
-            label="minimum idle time"
-          />
-        </q-field>
         <q-field label="Held by">
           <span>{{ mutexClients.active }}</span>
         </q-field>
@@ -57,6 +49,11 @@ export default class MutexWidget extends BlockWidget {
           <div class="column">
             <span v-for="client in mutexClients.idle" :key="client">{{ client }}</span>
           </div>
+        </q-field>
+        <q-field label="Wait time remaining">
+          <span>
+            {{block.data.waitRemaining | unit}}
+          </span>
         </q-field>
       </div>
     </q-card-main>

--- a/src/plugins/spark/features/Mutex/MutexWidget.vue
+++ b/src/plugins/spark/features/Mutex/MutexWidget.vue
@@ -51,9 +51,7 @@ export default class MutexWidget extends BlockWidget {
           </div>
         </q-field>
         <q-field label="Wait time remaining">
-          <span>
-            {{block.data.waitRemaining | unit}}
-          </span>
+          <span>{{ block.data.waitRemaining | unitDuration }}</span>
         </q-field>
       </div>
     </q-card-main>


### PR DESCRIPTION
This changes the wait time field in the mutex widget to display the time remaining instead of the minimum time setting.
Requires updated firmware that provides the value.