### PR TITLE
Show units in graph legend and always show legend

### DIFF
--- a/src/components/Graph/GraphDisplay.vue
+++ b/src/components/Graph/GraphDisplay.vue
@@ -31,6 +31,7 @@ export default class GraphDisplay extends Vue {
       b: 40,
     },
     legend: { orientation: 'h' },
+    showlegend: true,
     xaxis: {
       type: 'date',
       gridcolor: '#666',

--- a/src/helpers/units/index.ts
+++ b/src/helpers/units/index.ts
@@ -1,10 +1,10 @@
 import Link from './Link';
-import { serializedPropertyName, getDisplayNamesWithUnits } from './parseObject';
+import { serializedPropertyName, postfixedDisplayNames } from './parseObject';
 import Unit from './Unit';
 
 export {
   Unit,
   Link,
   serializedPropertyName,
-  getDisplayNamesWithUnits,
+  postfixedDisplayNames,
 };

--- a/src/helpers/units/index.ts
+++ b/src/helpers/units/index.ts
@@ -1,9 +1,10 @@
 import Link from './Link';
-import { serializedPropertyName } from './parseObject';
+import { serializedPropertyName, getDisplayNamesWithUnits } from './parseObject';
 import Unit from './Unit';
 
 export {
   Unit,
   Link,
   serializedPropertyName,
+  getDisplayNamesWithUnits,
 };

--- a/src/helpers/units/parseObject.ts
+++ b/src/helpers/units/parseObject.ts
@@ -41,6 +41,30 @@ export function serializedPropertyName(key: string, inputObject: any): string {
   return key;
 }
 
+export function getDisplayNamesWithUnits(
+  renames: { [key: string]: string }, inputObject: any): { [serializedKey: string]: string } {
+  const displayNames = {};
+  Object.entries(renames).map(([key, newName]) => {
+    let displayName = newName;
+    let unit = '';
+
+    if (Array.isArray(inputObject[key]) && inputObject[key][0] instanceof Unit) {
+      unit = inputObject.key[0].notation;
+    }
+    else if (inputObject[key] instanceof Unit) {
+      unit = inputObject[key].notation;
+    }
+    if (unit !== '') {
+      displayName = `${displayName} [${unit}]`;
+    }
+
+    const serializedName = serializedPropertyName(key, inputObject);
+    displayNames[serializedName] = displayName;
+  });
+
+  return displayNames;
+}
+
 export function convertToUnit(key: string, value: any): Unit | Link {
   const matched = key.match(extractUnit);
 

--- a/src/helpers/units/parseObject.ts
+++ b/src/helpers/units/parseObject.ts
@@ -13,6 +13,16 @@ export function propertyNameWithoutUnit(name: string): string {
   return matched ? matched[1] : name;
 }
 
+export function objectUnit(val: any): string | null {
+  if (Array.isArray(val) && val[0] instanceof Unit) {
+    return val[0].notation;
+  }
+  if (val instanceof Unit) {
+    return val.notation;
+  }
+  return null;
+}
+
 export function serializedPropertyName(key: string, inputObject: any): string {
   const input = inputObject[key];
 
@@ -41,28 +51,17 @@ export function serializedPropertyName(key: string, inputObject: any): string {
   return key;
 }
 
-export function getDisplayNamesWithUnits(
-  renames: { [key: string]: string }, inputObject: any): { [serializedKey: string]: string } {
-  const displayNames = {};
-  Object.entries(renames).map(([key, newName]) => {
-    let displayName = newName;
-    let unit = '';
+type DisplayNameType = { [key: string]: string };
 
-    if (Array.isArray(inputObject[key]) && inputObject[key][0] instanceof Unit) {
-      unit = inputObject.key[0].notation;
-    }
-    else if (inputObject[key] instanceof Unit) {
-      unit = inputObject[key].notation;
-    }
-    if (unit !== '') {
-      displayName = `${displayName} [${unit}]`;
-    }
+export function postfixedDisplayNames(displayNames: DisplayNameType, inputObject: any): DisplayNameType {
+  const displayNameReducer = (acc: DisplayNameType, [key, displayName]) => {
+    const serializedKey = serializedPropertyName(key, inputObject);
+    const unit = objectUnit(inputObject[key]);
+    return { ...acc, [serializedKey]: unit ? `${displayName} [${unit}]` : displayName };
+  };
 
-    const serializedName = serializedPropertyName(key, inputObject);
-    displayNames[serializedName] = displayName;
-  });
-
-  return displayNames;
+  return Object.entries(displayNames)
+    .reduce(displayNameReducer, {});
 }
 
 export function convertToUnit(key: string, value: any): Unit | Link {

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -290,6 +290,10 @@ export default class DefaultLayout extends Vue {
   cursor: move;
 }
 
+.q-card-title {
+  max-width: 100%;
+}
+
 .widget-container {
   height: 100%;
   width: 100%;

--- a/src/plugins/spark/features/Pid/PidWidget.vue
+++ b/src/plugins/spark/features/Pid/PidWidget.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { getDisplayNamesWithUnits } from '@/helpers/units';
+import { postfixedDisplayNames } from '@/helpers/units';
 import BlockWidget from '@/plugins/spark/components/BlockWidget';
 import Component from 'vue-class-component';
 import { filters, getById } from './getters';
@@ -12,19 +12,21 @@ export default class PidWidget extends BlockWidget {
   }
 
   get renamedTargets() {
-    return getDisplayNamesWithUnits({
-      inputSetting: 'Input target',
-      inputValue: 'Input value',
-      error: 'Error (filtered)',
-      derivative: 'Derivative or error',
-      integral: 'Integral of error',
-      p: 'P',
-      i: 'I',
-      d: 'D',
-      outputSetting: 'Output target (P+I+D)',
-      outputValue: 'Output value',
-    },
-    this.block.data);
+    return postfixedDisplayNames(
+      {
+        inputSetting: 'Input target',
+        inputValue: 'Input value',
+        error: 'Error (filtered)',
+        derivative: 'Derivative or error',
+        integral: 'Integral of error',
+        p: 'P',
+        i: 'I',
+        d: 'D',
+        outputSetting: 'Output target (P+I+D)',
+        outputValue: 'Output value',
+      },
+      this.block.data,
+    );
   }
 
   get filterName() {

--- a/src/plugins/spark/features/Pid/PidWidget.vue
+++ b/src/plugins/spark/features/Pid/PidWidget.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { serializedPropertyName } from '@/helpers/units';
+import { getDisplayNamesWithUnits } from '@/helpers/units';
 import BlockWidget from '@/plugins/spark/components/BlockWidget';
 import Component from 'vue-class-component';
 import { filters, getById } from './getters';
@@ -12,18 +12,19 @@ export default class PidWidget extends BlockWidget {
   }
 
   get renamedTargets() {
-    return {
-      [serializedPropertyName('error', this.block.data)]: 'Error (filtered)',
-      [serializedPropertyName('derivative', this.block.data)]: 'Derivative or error',
-      [serializedPropertyName('integral', this.block.data)]: 'Integral of error',
-      [serializedPropertyName('p', this.block.data)]: 'Proportional action',
-      [serializedPropertyName('i', this.block.data)]: 'Integral action',
-      [serializedPropertyName('d', this.block.data)]: 'Derivative action',
-      [serializedPropertyName('inputValue', this.block.data)]: 'Input value',
-      [serializedPropertyName('inputSetting', this.block.data)]: 'Input target',
-      [serializedPropertyName('outputValue', this.block.data)]: 'Output value',
-      [serializedPropertyName('outputSetting', this.block.data)]: 'Output target',
-    };
+    return getDisplayNamesWithUnits({
+      inputSetting: 'Input target',
+      inputValue: 'Input value',
+      error: 'Error (filtered)',
+      derivative: 'Derivative or error',
+      integral: 'Integral of error',
+      p: 'P',
+      i: 'I',
+      d: 'D',
+      outputSetting: 'Output target (P+I+D)',
+      outputValue: 'Output value',
+    },
+    this.block.data);
   }
 
   get filterName() {

--- a/src/plugins/spark/features/SetpointSensorPair/SetpointSensorPairWidget.vue
+++ b/src/plugins/spark/features/SetpointSensorPair/SetpointSensorPairWidget.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { serializedPropertyName } from '@/helpers/units';
+import { getDisplayNamesWithUnits } from '@/helpers/units';
 import BlockWidget from '@/plugins/spark/components/BlockWidget';
 import Component from 'vue-class-component';
 import { getById } from './getters';
@@ -12,10 +12,11 @@ export default class SetpointSensorPairWidget extends BlockWidget {
   }
 
   get renamedTargets() {
-    return {
-      [serializedPropertyName('setpointValue', this.block.data)]: 'Setpoint',
-      [serializedPropertyName('sensorValue', this.block.data)]: 'Sensor',
-    };
+    return getDisplayNamesWithUnits({
+      setpointValue: 'Setpoint',
+      sensorValue: 'Sensor',
+    },
+      this.block.data);
   }
 }
 </script>

--- a/src/plugins/spark/features/SetpointSensorPair/SetpointSensorPairWidget.vue
+++ b/src/plugins/spark/features/SetpointSensorPair/SetpointSensorPairWidget.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { getDisplayNamesWithUnits } from '@/helpers/units';
+import { postfixedDisplayNames } from '@/helpers/units';
 import BlockWidget from '@/plugins/spark/components/BlockWidget';
 import Component from 'vue-class-component';
 import { getById } from './getters';
@@ -12,11 +12,13 @@ export default class SetpointSensorPairWidget extends BlockWidget {
   }
 
   get renamedTargets() {
-    return getDisplayNamesWithUnits({
-      setpointValue: 'Setpoint',
-      sensorValue: 'Sensor',
-    },
-      this.block.data);
+    return postfixedDisplayNames(
+      {
+        setpointValue: 'Setpoint',
+        sensorValue: 'Sensor',
+      },
+      this.block.data,
+    );
   }
 }
 </script>

--- a/src/plugins/spark/features/SetpointSimple/SetpointSimpleWidget.vue
+++ b/src/plugins/spark/features/SetpointSimple/SetpointSimpleWidget.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Unit, getDisplayNamesWithUnits } from '@/helpers/units';
+import { Unit, postfixedDisplayNames } from '@/helpers/units';
 import BlockWidget from '@/plugins/spark/components/BlockWidget';
 import { isNullOrUndefined } from 'util';
 import Component from 'vue-class-component';
@@ -13,10 +13,12 @@ export default class SetpointSimpleWidget extends BlockWidget {
   }
 
   get renamedTargets() {
-    return getDisplayNamesWithUnits({
-      setting: 'Setpoint setting',
-    },
-      this.block.data);
+    return postfixedDisplayNames(
+      {
+        setting: 'Setpoint setting',
+      },
+      this.block.data,
+    );
   }
 }
 </script>

--- a/src/plugins/spark/features/SetpointSimple/SetpointSimpleWidget.vue
+++ b/src/plugins/spark/features/SetpointSimple/SetpointSimpleWidget.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { Unit } from '@/helpers/units';
+import { Unit, getDisplayNamesWithUnits } from '@/helpers/units';
 import BlockWidget from '@/plugins/spark/components/BlockWidget';
 import { isNullOrUndefined } from 'util';
 import Component from 'vue-class-component';
@@ -10,6 +10,13 @@ import { SetpointSimpleBlock } from './state';
 export default class SetpointSimpleWidget extends BlockWidget {
   get block(): SetpointSimpleBlock {
     return getById(this.$store, this.serviceId, this.blockId);
+  }
+
+  get renamedTargets() {
+    return getDisplayNamesWithUnits({
+      setting: 'Setpoint setting',
+    },
+      this.block.data);
   }
 }
 </script>
@@ -29,6 +36,7 @@ export default class SetpointSimpleWidget extends BlockWidget {
     <q-card-title class="title-bar">
       <div class="ellipsis">{{ widgetId }}</div>
       <span slot="right" class="vertical-middle on-left">{{ displayName }}</span>
+      <BlockGraph slot="right" :id="widgetId" :config="graphCfg" :change="v => graphCfg = v"/>
       <q-btn slot="right" flat round dense icon="settings" @click="openModal"/>
       <q-btn slot="right" flat round dense icon="refresh" @click="refreshBlock"/>
     </q-card-title>

--- a/src/plugins/spark/features/TempSensorMock/TempSensorMockWidget.vue
+++ b/src/plugins/spark/features/TempSensorMock/TempSensorMockWidget.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { getDisplayNamesWithUnits } from '@/helpers/units';
+import { postfixedDisplayNames } from '@/helpers/units';
 import BlockWidget from '@/plugins/spark/components/BlockWidget';
 import Component from 'vue-class-component';
 import { getById } from './getters';
@@ -12,10 +12,12 @@ export default class TempSensorMockWidget extends BlockWidget {
   }
 
   get renamedTargets() {
-    return getDisplayNamesWithUnits({
-      value: 'Sensor value',
-    },
-      this.block.data);
+    return postfixedDisplayNames(
+      {
+        value: 'Sensor value',
+      },
+      this.block.data,
+    );
   }
 }
 </script>

--- a/src/plugins/spark/features/TempSensorMock/TempSensorMockWidget.vue
+++ b/src/plugins/spark/features/TempSensorMock/TempSensorMockWidget.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { serializedPropertyName } from '@/helpers/units';
+import { getDisplayNamesWithUnits } from '@/helpers/units';
 import BlockWidget from '@/plugins/spark/components/BlockWidget';
 import Component from 'vue-class-component';
 import { getById } from './getters';
@@ -12,9 +12,10 @@ export default class TempSensorMockWidget extends BlockWidget {
   }
 
   get renamedTargets() {
-    return {
-      [serializedPropertyName('value', this.block.data)]: 'Value',
-    };
+    return getDisplayNamesWithUnits({
+      value: 'Sensor value',
+    },
+      this.block.data);
   }
 }
 </script>

--- a/src/plugins/spark/features/TempSensorOneWire/TempSensorOneWireWidget.vue
+++ b/src/plugins/spark/features/TempSensorOneWire/TempSensorOneWireWidget.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { serializedPropertyName } from '@/helpers/units';
+import { getDisplayNamesWithUnits } from '@/helpers/units';
 import BlockWidget from '@/plugins/spark/components/BlockWidget';
 import Component from 'vue-class-component';
 import { getById } from './getters';
@@ -12,10 +12,10 @@ export default class TempSensorOneWireWidget extends BlockWidget {
   }
 
   get renamedTargets() {
-    return {
-      [serializedPropertyName('value', this.block.data)]: 'Value',
-      [serializedPropertyName('offset', this.block.data)]: 'Offset',
-    };
+    return getDisplayNamesWithUnits({
+      value: 'Sensor value',
+    },
+      this.block.data);
   }
 }
 </script>

--- a/src/plugins/spark/features/TempSensorOneWire/TempSensorOneWireWidget.vue
+++ b/src/plugins/spark/features/TempSensorOneWire/TempSensorOneWireWidget.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { getDisplayNamesWithUnits } from '@/helpers/units';
+import { postfixedDisplayNames } from '@/helpers/units';
 import BlockWidget from '@/plugins/spark/components/BlockWidget';
 import Component from 'vue-class-component';
 import { getById } from './getters';
@@ -12,10 +12,12 @@ export default class TempSensorOneWireWidget extends BlockWidget {
   }
 
   get renamedTargets() {
-    return getDisplayNamesWithUnits({
-      value: 'Sensor value',
-    },
-      this.block.data);
+    return postfixedDisplayNames(
+      {
+        value: 'Sensor value',
+      },
+      this.block.data,
+    );
   }
 }
 </script>


### PR DESCRIPTION
Added a new helper function to extract unit notation from fields to show them in the graph legend.

Also changes some legend names to be clearer and always enabled the legend in charts (even when just one line is shown).