### PR TITLE
Optimize processview to render as single SVG

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7150,7 +7150,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7171,12 +7172,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7191,17 +7194,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7318,7 +7324,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7330,6 +7337,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7344,6 +7352,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7351,12 +7360,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7375,6 +7386,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7455,7 +7467,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7467,6 +7480,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7552,7 +7566,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7588,6 +7603,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7607,6 +7623,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7650,12 +7667,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -14659,6 +14678,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "svg-path-properties": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/svg-path-properties/-/svg-path-properties-0.4.8.tgz",
+      "integrity": "sha512-xlkeXafQQ58MYl8/k4Fbw9ssgzpdlN5caHiBSB03eI1y4EKUVdIS6+A4KbPni1fz2o29DAco2aHeLppQlBSLyQ=="
     },
     "svgo": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "quasar-framework": "^0.17.18",
     "query-string": "^6.2.0",
     "shortid": "^2.2.14",
+    "svg-path-properties": "^0.4.8",
     "typescript": "^3.2.4",
     "url-safe-string": "^1.1.0",
     "vue": "^2.5.21",

--- a/src/plugins/spark/features/ProcessView/ProcessViewWidget.vue
+++ b/src/plugins/spark/features/ProcessView/ProcessViewWidget.vue
@@ -68,10 +68,6 @@ export default class ProcessViewWidget extends WidgetBase {
     return `translate(${part.x * SQUARE_SIZE}, ${part.y * SQUARE_SIZE})`;
   }
 
-  partRotate(part: PersistentPart) {
-    return `rotate(${part.rotate})`;
-  }
-
   gridContains(x: number, y: number) {
     const { left, right, top, bottom } = this.gridRect;
     return x >= left
@@ -207,12 +203,11 @@ export default class ProcessViewWidget extends WidgetBase {
         <rect fill="none" x="0" y="0" width="50" height="50"/>
         <ProcessViewItem
           :value="flowParts[idx]"
-          :transform="partRotate(part)"
           @input="v => updatePart(idx, v)"
         />
       </g>
       <g v-if="dragAction" :transform="`translate(${dragAction.x}, ${dragAction.y})`">
-        <ProcessViewItem :value="dragAction.part" :transform="partRotate(dragAction.part)"/>
+        <ProcessViewItem :value="dragAction.part"/>
       </g>
     </svg>
   </q-card>

--- a/src/plugins/spark/features/ProcessView/ProcessViewWidget.vue
+++ b/src/plugins/spark/features/ProcessView/ProcessViewWidget.vue
@@ -172,8 +172,8 @@ export default class ProcessViewWidget extends WidgetBase {
         <q-popover>
           <q-list link style="padding: 5px">
             <q-item v-for="part in availableParts" :key="part.type">
-              <svg>
-                <ProcessViewItem v-touch-pan="v => panHandler(part, v)" :value="part"/>
+              <svg v-touch-pan="v => panHandler(part, v)">
+                <ProcessViewItem :value="part"/>
               </svg>
             </q-item>
           </q-list>
@@ -191,7 +191,6 @@ export default class ProcessViewWidget extends WidgetBase {
         :transform="partTranslate(part)"
         :key="`${part.x}_${part.y}`"
         class="grid-item"
-        pointer-events="bounding-box"
       >
         <text
           v-if="editable"
@@ -200,11 +199,11 @@ export default class ProcessViewWidget extends WidgetBase {
           y="8"
           class="grid-item-coordinates"
         >{{ part.x }},{{ part.y }}</text>
-        <rect fill="none" x="0" y="0" width="50" height="50"/>
         <ProcessViewItem
           :value="flowParts[idx]"
           @input="v => updatePart(idx, v)"
         />
+        <rect v-if="editable" fill="red" fill-opacity="0" x="0" y="0" width="50" height="50"/>
       </g>
       <g v-if="dragAction" :transform="`translate(${dragAction.x}, ${dragAction.y})`">
         <ProcessViewItem :value="dragAction.part"/>

--- a/src/plugins/spark/features/ProcessView/calculateFlows.ts
+++ b/src/plugins/spark/features/ProcessView/calculateFlows.ts
@@ -273,6 +273,6 @@ export const pathsFromSources = (parts: PersistentPart[]): FlowPart[] => {
         .toString(),
       part.liquidSource,
     )) // -> FlowPart[][]
-    .reduce(mergeSourceFlows, []) // -> FlowPart[]
+    .reduce(mergeSourceFlows, flowParts) // -> FlowPart[]
     .map(normalizeFlows);
 };

--- a/src/plugins/spark/features/ProcessView/components/AnimatedArrows.vue
+++ b/src/plugins/spark/features/ProcessView/components/AnimatedArrows.vue
@@ -2,6 +2,7 @@
 /* eslint-disable vue/attribute-hyphenation */
 import Vue from 'vue';
 import Component from 'vue-class-component';
+import { svgPathProperties } from 'svg-path-properties';
 
 @Component({
   props: {
@@ -9,42 +10,56 @@ import Component from 'vue-class-component';
       type: String,
       required: true,
     },
-    duration: {
+    speed: {
       type: Number,
-      default: 2,
+      default: 0,
     },
     numArrows: {
       type: Number,
       default: 2,
     },
-    reversed: {
-      type: Boolean,
-      default: false,
-    },
   },
 })
 export default class AnimatedArrows extends Vue {
+  get pathLength (){
+    return svgPathProperties(this.$props.path).getTotalLength();
+  }
+
+  get duration(){
+    if(this.$props.speed && this.pathLength){
+      return this.pathLength / (10 * Math.abs(this.$props.speed));
+    }
+    return 0;
+  }
+
+  get reversed(){
+    return this.$props.speed < 0;
+  }
+
   get starts(): string[] {
-    const interval = this.$props.duration / this.$props.numArrows;
+    const interval = this.duration / this.$props.numArrows;
     return [...Array(this.$props.numArrows).keys()]
       .map(idx => `${idx * interval}s`);
   }
 
   get transform() {
     // Flips the arrow
-    return this.$props.reversed
+    return this.reversed
       ? 'scale (-1, 1)'
       : '';
   }
 
   get keyPoints() {
     // Makes the arrow travel end-to-start
-    return this.$props.reversed
+    return this.reversed
       ? '1;0'
       : '0;1';
   }
 
   mounted() {
+    console.log(this.$refs.animation);
+    // this.pathLength = this.$refs.animationPath.getTotalLength();
+    // console.log(this.pathLength);
     interface AnimateMotion extends Element {
       beginElementAt(v: number);
       getStartTime(): number;
@@ -61,13 +76,13 @@ export default class AnimatedArrows extends Vue {
 <template>
   <g>
     <g v-for="start in starts" :key="start" visibility="hidden">
-      <path :transform="transform" d="M0,0 l4,4 l-4,4" class="outline"/>
+      <path :transform="transform" d="M-4,-4 L0,0 M-4,4 L0,0" class="outline"/>
       <!-- Note: SVG attributes are case-sensitive -->
       <animateMotion
         :path="$props.path"
         :begin="start"
         :keyPoints="keyPoints"
-        :dur="`${$props.duration}s`"
+        :dur="`${duration}s`"
         fill="freeze"
         repeatCount="indefinite"
         rotate="auto"

--- a/src/plugins/spark/features/ProcessView/components/AnimatedArrows.vue
+++ b/src/plugins/spark/features/ProcessView/components/AnimatedArrows.vue
@@ -55,21 +55,6 @@ export default class AnimatedArrows extends Vue {
       ? '1;0'
       : '0;1';
   }
-
-  mounted() {
-    console.log(this.$refs.animation);
-    // this.pathLength = this.$refs.animationPath.getTotalLength();
-    // console.log(this.pathLength);
-    interface AnimateMotion extends Element {
-      beginElementAt(v: number);
-      getStartTime(): number;
-    }
-    const allAnimations = document.getElementsByTagName('animateMotion');
-    [...allAnimations].forEach(element => {
-      const motion = (element as AnimateMotion);
-      motion.beginElementAt(motion.getStartTime());
-    });
-  }
 }
 </script>
 

--- a/src/plugins/spark/features/ProcessView/components/PartComponent.ts
+++ b/src/plugins/spark/features/ProcessView/components/PartComponent.ts
@@ -44,11 +44,6 @@ export default class PartComponent extends Vue {
     return Boolean(this.part.disabled);
   }
 
-  get flowing(): boolean {
-    return Object.keys(this.flow)
-      .some(angle => this.flowOnAngle(angle) !== 0);
-  }
-
   get flow() {
     return this.part.calculated || {};
   }

--- a/src/plugins/spark/features/ProcessView/components/ProcessViewItem.vue
+++ b/src/plugins/spark/features/ProcessView/components/ProcessViewItem.vue
@@ -1,6 +1,8 @@
 <script lang="ts">
 import Vue from 'vue';
 import Component from 'vue-class-component';
+import { ComponentConstructor } from '../state';
+import { SQUARE_SIZE } from '../getters';
 
 @Component({
   props: {
@@ -17,8 +19,19 @@ export default class ProcessViewItem extends Vue {
       : {};
   }
 
-  get component() {
-    return Vue.component(this.$props.value.type);
+  get component(): ComponentConstructor {
+    return Vue.component(this.$props.value.type) as ComponentConstructor;
+  }
+
+  get size() {
+    if (this.component.size !== undefined) {
+      return this.component.size(this.$props.value);
+    }
+    return [1, 1];
+  }
+
+  get transformOrigin() {
+    return this.size.map(v => v * SQUARE_SIZE / 2).join(' ');
   }
 }
 </script>
@@ -29,6 +42,7 @@ export default class ProcessViewItem extends Vue {
     :style="style"
     :value="value"
     :is="component"
+    :transform-origin="transformOrigin"
     class="ProcessViewPart"
   />
 </template>

--- a/src/plugins/spark/features/ProcessView/components/ProcessViewItem.vue
+++ b/src/plugins/spark/features/ProcessView/components/ProcessViewItem.vue
@@ -13,12 +13,6 @@ import { SQUARE_SIZE } from '../getters';
   },
 })
 export default class ProcessViewItem extends Vue {
-  get style() {
-    return this.$props.value.rotate
-      ? { transform: `rotate(${this.$props.value.rotate}deg)` }
-      : {};
-  }
-
   get component(): ComponentConstructor {
     return Vue.component(this.$props.value.type) as ComponentConstructor;
   }
@@ -30,21 +24,26 @@ export default class ProcessViewItem extends Vue {
     return [1, 1];
   }
 
-  get transformOrigin() {
-    return this.size.map(v => v * SQUARE_SIZE / 2).join(' ');
+  // to rotate correctly in all browsers, center part around 0,0 before rotation
+  // Firefox does not support transform-origin in SVG.
+  get center() {
+    return this.size.map(v => v * SQUARE_SIZE / 2);
   }
 }
 </script>
 
 <template>
-  <component
-    v-if="component"
-    :style="style"
-    :value="value"
-    :is="component"
-    :transform-origin="transformOrigin"
-    class="ProcessViewPart"
-  />
+  <g :transform="`translate(${center.join(',')})`">
+    <g :transform="`rotate(${value.rotate})`">
+      <component
+        v-if="component"
+        :value="value"
+        :is="component"
+        :transform="`translate(${center.map(v => -v).join(',')})`"
+        class="ProcessViewPart"
+      />
+    </g>
+  </g>
 </template>
 
 <style>

--- a/src/plugins/spark/features/ProcessView/parts/BridgeTube.vue
+++ b/src/plugins/spark/features/ProcessView/parts/BridgeTube.vue
@@ -101,7 +101,7 @@ export default class BridgeTube extends PartComponent {
 </script>
 
 <template>
-  <SVGRoot>
+  <g class="bridge-tube">
     <!-- low -->
     <g class="outline">
       <path :d="lowPaths.borders[0]"/>
@@ -120,7 +120,7 @@ export default class BridgeTube extends PartComponent {
       <path :d="highPaths.liquid"/>
     </g>
     <AnimatedArrows v-if="highFlowing" :reversed="highReversed" :path="highPaths.borders[0]"/>
-  </SVGRoot>
+  </g>
 </template>
 
 

--- a/src/plugins/spark/features/ProcessView/parts/BridgeTube.vue
+++ b/src/plugins/spark/features/ProcessView/parts/BridgeTube.vue
@@ -37,12 +37,12 @@ export default class BridgeTube extends PartComponent {
     return (this.flow[LEFT] || this.flow[RIGHT]) !== undefined;
   }
 
-  get lowFlowing(): boolean {
-    return (this.flow[UP] || this.flow[DOWN] || 0) !== 0;
+  get lowFlowSpeed() {
+    return this.flow[UP];
   }
 
-  get highFlowing(): boolean {
-    return (this.flow[LEFT] || this.flow[RIGHT] || 0) !== 0;
+  get highFlowSpeed() {
+    return this.flow[LEFT];
   }
 
   get lowPaths() {
@@ -110,7 +110,7 @@ export default class BridgeTube extends PartComponent {
     <g v-if="lowLiquid" :stroke="liquidColor" class="liquid">
       <path :d="lowPaths.liquid"/>
     </g>
-    <AnimatedArrows v-if="lowFlowing" :reversed="lowReversed" :path="lowPaths.borders[0]"/>
+    <AnimatedArrows v-if="lowFlowSpeed" :speed="lowFlowSpeed" :path="lowPaths.liquid"/>
     <!-- high -->
     <g class="outline">
       <path :d="highPaths.borders[0]"/>
@@ -119,7 +119,7 @@ export default class BridgeTube extends PartComponent {
     <g v-show="highLiquid" :stroke="liquidColor" class="liquid">
       <path :d="highPaths.liquid"/>
     </g>
-    <AnimatedArrows v-if="highFlowing" :reversed="highReversed" :path="highPaths.borders[0]"/>
+    <AnimatedArrows v-if="highFlowSpeed" :speed="highFlowSpeed" :path="highPaths.liquid"/>
   </g>
 </template>
 

--- a/src/plugins/spark/features/ProcessView/parts/ElbowTube.vue
+++ b/src/plugins/spark/features/ProcessView/parts/ElbowTube.vue
@@ -30,7 +30,7 @@ export default class ElbowTube extends PartComponent {
 </script>
 
 <template>
-  <SVGRoot>
+  <g class="elbow-tube">
     <g class="outline">
       <path :d="paths.borders[0]"/>
       <path :d="paths.borders[1]"/>
@@ -39,7 +39,7 @@ export default class ElbowTube extends PartComponent {
       <path :d="paths.liquid"/>
     </g>
     <AnimatedArrows v-if="flowing" :reversed="reversed" :path="paths.borders[1]"/>
-  </SVGRoot>
+  </g>
 </template>
 
 

--- a/src/plugins/spark/features/ProcessView/parts/ElbowTube.vue
+++ b/src/plugins/spark/features/ProcessView/parts/ElbowTube.vue
@@ -13,10 +13,6 @@ export default class ElbowTube extends PartComponent {
     };
   }
 
-  get reversed() {
-    return this.flowOnAngle(UP) > 0;
-  }
-
   get paths() {
     return {
       borders: [
@@ -25,6 +21,10 @@ export default class ElbowTube extends PartComponent {
       ],
       liquid: 'M25,0V20a5,5,0,0,0,5,5H50',
     };
+  }
+
+  get flowSpeed(){
+    return this.flow[RIGHT];
   }
 }
 </script>
@@ -38,7 +38,7 @@ export default class ElbowTube extends PartComponent {
     <g v-if="liquid" :stroke="liquidColor" class="liquid">
       <path :d="paths.liquid"/>
     </g>
-    <AnimatedArrows v-if="flowing" :reversed="reversed" :path="paths.borders[1]"/>
+    <AnimatedArrows v-if="flowSpeed" :speed="flowSpeed" :path="'M25,0V16a9,9,0,0,0,9,9H50'"/>
   </g>
 </template>
 

--- a/src/plugins/spark/features/ProcessView/parts/InputTube.vue
+++ b/src/plugins/spark/features/ProcessView/parts/InputTube.vue
@@ -38,7 +38,7 @@ export default class InputTube extends PartComponent {
 </script>
 
 <template>
-  <SVGRoot>
+  <g class="input-tube">
     <g class="outline">
       <polyline points="1.25 17.5 8.75 25 1.25 32.5"/>
       <polyline points="9.13 19.25 14.88 25 9.13 30.75"/>
@@ -50,7 +50,7 @@ export default class InputTube extends PartComponent {
       <path :d="paths.liquid"/>
     </g>
     <AnimatedArrows v-if="flowing" :path="paths.borders[0]" :num-arrows="1" :duration="1"/>
-  </SVGRoot>
+  </g>
 </template>
 
 

--- a/src/plugins/spark/features/ProcessView/parts/InputTube.vue
+++ b/src/plugins/spark/features/ProcessView/parts/InputTube.vue
@@ -21,10 +21,6 @@ export default class InputTube extends PartComponent {
     };
   }
 
-  get flowing() {
-    return this.flowOnAngle(RIGHT) > 0;
-  }
-
   get paths() {
     return {
       borders: [
@@ -33,6 +29,10 @@ export default class InputTube extends PartComponent {
       ],
       liquid: 'M30,25 H50',
     };
+  }
+
+  get flowSpeed(){
+    return this.flowOnAngle(RIGHT);
   }
 }
 </script>
@@ -49,7 +49,7 @@ export default class InputTube extends PartComponent {
     <g v-if="liquid" :stroke="liquidColor" class="liquid">
       <path :d="paths.liquid"/>
     </g>
-    <AnimatedArrows v-if="flowing" :path="paths.borders[0]" :num-arrows="1" :duration="1"/>
+    <AnimatedArrows v-if="flowSpeed" :num-arrows="1" :speed="flowSpeed" path="M25,25H50"/>
   </g>
 </template>
 

--- a/src/plugins/spark/features/ProcessView/parts/OutputTube.vue
+++ b/src/plugins/spark/features/ProcessView/parts/OutputTube.vue
@@ -22,6 +22,10 @@ export default class OutputTube extends PartComponent {
       liquid: 'M0,25 H20',
     };
   }
+
+  get flowSpeed(){
+    return -this.flow[LEFT];
+  }
 }
 </script>
 
@@ -37,7 +41,7 @@ export default class OutputTube extends PartComponent {
     <g v-if="liquid" :stroke="liquidColor" class="liquid">
       <path :d="paths.liquid"/>
     </g>
-    <AnimatedArrows v-if="flowing" :path="paths.borders[0]" :num-arrows="1" :duration="1"/>
+    <AnimatedArrows v-if="flowSpeed" :num-arrows="1" :speed="flowSpeed" path="M0,25H25"/>
   </g>
 </template>
 

--- a/src/plugins/spark/features/ProcessView/parts/OutputTube.vue
+++ b/src/plugins/spark/features/ProcessView/parts/OutputTube.vue
@@ -26,7 +26,7 @@ export default class OutputTube extends PartComponent {
 </script>
 
 <template>
-  <SVGRoot>
+  <g class="ouput-tube">
     <g class="outline">
       <polyline points="40.5,17.5 48,25 40.5,32.5"/>
       <polyline points="36.4,19.3 42.1,25 36.4,30.8"/>
@@ -38,7 +38,7 @@ export default class OutputTube extends PartComponent {
       <path :d="paths.liquid"/>
     </g>
     <AnimatedArrows v-if="flowing" :path="paths.borders[0]" :num-arrows="1" :duration="1"/>
-  </SVGRoot>
+  </g>
 </template>
 
 

--- a/src/plugins/spark/features/ProcessView/parts/Pump.vue
+++ b/src/plugins/spark/features/ProcessView/parts/Pump.vue
@@ -59,6 +59,7 @@ export default class Pump extends PartComponent {
       <line class="st0" x1="0" y1="29" x2="9" y2="29"/>
       <path d="M50,29H29v3.5c0,2.2-1.8,4-4,4s-4-1.8-4-4V25c0-2.2,1.8-4,4-4h25"/>
     </g>
+    <rect fill="red" fill-opacity="0" x="0" y="0" width="50" height="50"/>
   </g>
 </template>
 

--- a/src/plugins/spark/features/ProcessView/parts/Pump.vue
+++ b/src/plugins/spark/features/ProcessView/parts/Pump.vue
@@ -27,11 +27,11 @@ export default class Pump extends PartComponent {
       <circle cx="25" cy="30" r="16"/>
     </g>
     <!-- blades -->
-    <g class="blades-wrapper" transform="translate(0,5)">
-      <g class="outline" transform-origin="25 25">
-        <line x1="25" y1="39" x2="25" y2="11"/>
-        <line x1="37.1" y1="32" x2="12.9" y2="18"/>
-        <line x1="37.1" y1="18" x2="12.9" y2="32"/>
+    <g class="blades-wrapper" transform="translate(25,30)">
+      <g class="outline">
+        <line x1="-14" y1="0" x2="14" y2="0"/>
+        <line x1="7" y1="-12.1" x2="-7" y2="12.1"/>
+        <line x1="7" y1="12.1" x2="-7" y2="-12.1"/>
         <!-- eslint-disable vue/attribute-hyphenation -->
         <animateTransform
           v-if="!part.disabled"

--- a/src/plugins/spark/features/ProcessView/parts/Pump.vue
+++ b/src/plugins/spark/features/ProcessView/parts/Pump.vue
@@ -17,59 +17,48 @@ export default class Pump extends PartComponent {
 </script>
 
 <template>
-  <div class="clickable" @click="toggleDisabled">
-    <SVGRoot>
-      <!-- ball -->
-      <g v-if="liquid" :fill="liquidColor" class="liquid">
-        <circle cx="25" cy="30" r="16"/>
+  <g class="pump clickable" @click="toggleDisabled">
+    <!-- ball -->
+    <g v-if="liquid" :fill="liquidColor" class="liquid">
+      <circle cx="25" cy="30" r="16"/>
+    </g>
+    <!-- ball liquid -->
+    <g class="outline">
+      <circle cx="25" cy="30" r="16"/>
+    </g>
+    <!-- blades -->
+    <g class="blades-wrapper" transform="translate(0,5)">
+      <g class="outline" transform-origin="25 25">
+        <line x1="25" y1="39" x2="25" y2="11"/>
+        <line x1="37.1" y1="32" x2="12.9" y2="18"/>
+        <line x1="37.1" y1="18" x2="12.9" y2="32"/>
+        <!-- eslint-disable vue/attribute-hyphenation -->
+        <animateTransform
+          v-if="!part.disabled"
+          attributeName="transform"
+          attributeType="XML"
+          type="rotate"
+          from="0 0 0"
+          to="-360 0 0"
+          dur="3s"
+          repeatCount="indefinite"
+        />
+        <!-- eslint-enable -->
       </g>
-      <!-- ball liquid -->
-      <g class="outline">
-        <circle cx="25" cy="30" r="16"/>
-      </g>
-      <!-- blades -->
-      <g class="blades-wrapper">
-        <g class="outline center-rotate">
-          <line x1="25" y1="39" x2="25" y2="11"/>
-          <line x1="37.1" y1="32" x2="12.9" y2="18"/>
-          <line x1="37.1" y1="18" x2="12.9" y2="32"/>
-          <!-- eslint-disable vue/attribute-hyphenation -->
-          <animateTransform
-            v-if="!part.disabled"
-            attributeName="transform"
-            attributeType="XML"
-            type="rotate"
-            from="0 0 0"
-            to="-360 0 0"
-            dur="3s"
-            repeatCount="indefinite"
-          />
-          <!-- eslint-enable -->
-        </g>
-      </g>
-      <!-- tube liquid -->
-      <g v-if="liquid" :stroke="liquidColor" class="liquid">
-        <polyline points="25,33 25,25 50,25 "/>
-        <line class="st0" x1="0" y1="25" x2="10" y2="25"/>
-      </g>
-      <!-- tubes -->
-      <g class="outline">
-        <polyline points="20.5,10 16.5,6 20.5,2 "/>
-        <line class="st0" x1="32.5" y1="6" x2="16.5" y2="6"/>
-        <line class="st0" x1="0" y1="21" x2="11" y2="21"/>
-        <line class="st0" x1="0" y1="29" x2="9" y2="29"/>
-        <path d="M50,29H29v3.5c0,2.2-1.8,4-4,4s-4-1.8-4-4V25c0-2.2,1.8-4,4-4h25"/>
-      </g>
-    </SVGRoot>
-  </div>
+    </g>
+    <!-- tube liquid -->
+    <g v-if="liquid" :stroke="liquidColor" class="liquid">
+      <polyline points="25,33 25,25 50,25 "/>
+      <line class="st0" x1="0" y1="25" x2="10" y2="25"/>
+    </g>
+    <!-- tubes -->
+    <g class="outline">
+      <polyline points="20.5,10 16.5,6 20.5,2 "/>
+      <line class="st0" x1="32.5" y1="6" x2="16.5" y2="6"/>
+      <line class="st0" x1="0" y1="21" x2="11" y2="21"/>
+      <line class="st0" x1="0" y1="29" x2="9" y2="29"/>
+      <path d="M50,29H29v3.5c0,2.2-1.8,4-4,4s-4-1.8-4-4V25c0-2.2,1.8-4,4-4h25"/>
+    </g>
+  </g>
 </template>
 
-
-<style scoped>
-.blades-wrapper {
-  transform: translateY(5px);
-}
-.center-rotate {
-  transform-origin: 25px 25px;
-}
-</style>

--- a/src/plugins/spark/features/ProcessView/parts/StraightTube.vue
+++ b/src/plugins/spark/features/ProcessView/parts/StraightTube.vue
@@ -30,7 +30,7 @@ export default class StraightTube extends PartComponent {
 </script>
 
 <template>
-  <SVGRoot>
+  <g class="straight-tube">
     <g class="outline">
       <path :d="paths.borders[0]"/>
       <path :d="paths.borders[1]"/>
@@ -39,7 +39,7 @@ export default class StraightTube extends PartComponent {
       <path :d="paths.liquid"/>
     </g>
     <AnimatedArrows v-if="flowing" :reversed="reversed" :path="paths.borders[0]"/>
-  </SVGRoot>
+  </g>
 </template>
 
 

--- a/src/plugins/spark/features/ProcessView/parts/StraightTube.vue
+++ b/src/plugins/spark/features/ProcessView/parts/StraightTube.vue
@@ -13,18 +13,18 @@ export default class StraightTube extends PartComponent {
     };
   }
 
-  get reversed() {
-    return this.flowOnAngle(RIGHT) > 0;
-  }
-
   get paths() {
     return {
       borders: [
-        'M 50,29 H 0',
-        'M 50,21 H 0',
+        'M 0,21 H 50',
+        'M 0,29 H 50',
       ],
-      liquid: 'M 50,25 H 0',
+      liquid: 'M 0,25 H 50',
     };
+  }
+
+  get flowSpeed(){
+    return this.flow[RIGHT];
   }
 }
 </script>
@@ -38,7 +38,7 @@ export default class StraightTube extends PartComponent {
     <g v-if="liquid" :stroke="liquidColor" class="liquid">
       <path :d="paths.liquid"/>
     </g>
-    <AnimatedArrows v-if="flowing" :reversed="reversed" :path="paths.borders[0]"/>
+    <AnimatedArrows v-if="flowSpeed" :speed="flowSpeed" path="M0,25H50"/>
   </g>
 </template>
 

--- a/src/plugins/spark/features/ProcessView/parts/TeeTube.vue
+++ b/src/plugins/spark/features/ProcessView/parts/TeeTube.vue
@@ -49,7 +49,7 @@ export default class TeeTube extends PartComponent {
 </script>
 
 <template>
-  <SVGRoot>
+  <g class="tee-tube">
     <g class="outline">
       <path d="M50,21H30a1,1,0,0,1-1-1V0"/>
       <path d="M21,0V20a1,1,0,0,1-1,1H0"/>
@@ -83,7 +83,7 @@ export default class TeeTube extends PartComponent {
         :duration="1"
       />
     </g>
-  </SVGRoot>
+  </g>
 </template>
 
 

--- a/src/plugins/spark/features/ProcessView/parts/TeeTube.vue
+++ b/src/plugins/spark/features/ProcessView/parts/TeeTube.vue
@@ -16,34 +16,21 @@ export default class TeeTube extends PartComponent {
 
   get paths() {
     return {
-      top: 'M29,0 V24',
-      left: 'M50,29 H28',
-      right: 'M0,21 H21',
+      top: 'M25,25 V0',
+      left: 'M25,25 H0',
+      right: 'M25,25 H50',
     };
   }
 
-  get topFlowing() {
-    return Boolean(this.flowOnAngle(UP));
+  get topSpeed() {
+    return this.flowOnAngle(UP);
   }
 
-  get topReversed() {
-    return this.flowOnAngle(UP) > 0;
+  get leftSpeed() {
+    return this.flowOnAngle(LEFT);
   }
-
-  get leftFlowing() {
-    return Boolean(this.flowOnAngle(RIGHT));
-  }
-
-  get leftReversed() {
-    return this.flowOnAngle(RIGHT) > 0;
-  }
-
-  get rightFlowing() {
-    return Boolean(this.flowOnAngle(LEFT));
-  }
-
-  get rightReversed() {
-    return this.flowOnAngle(LEFT) > 0;
+  get rightSpeed() {
+    return this.flowOnAngle(RIGHT);
   }
 }
 </script>
@@ -62,25 +49,22 @@ export default class TeeTube extends PartComponent {
     </g>
     <g class="outline">
       <AnimatedArrows
-        v-if="topFlowing"
+        v-if="topSpeed"
         :path="paths.top"
-        :reversed="topReversed"
         :num-arrows="1"
-        :duration="1"
+        :speed="topSpeed"
       />
       <AnimatedArrows
-        v-if="leftFlowing"
+        v-if="leftSpeed"
         :path="paths.left"
-        :reversed="leftReversed"
         :num-arrows="1"
-        :duration="1"
+        :speed="leftSpeed"
       />
       <AnimatedArrows
-        v-if="rightFlowing"
+        v-if="rightSpeed"
         :path="paths.right"
-        :reversed="rightReversed"
         :num-arrows="1"
-        :duration="1"
+        :speed="rightSpeed"
       />
     </g>
   </g>

--- a/src/plugins/spark/features/ProcessView/parts/Valve.vue
+++ b/src/plugins/spark/features/ProcessView/parts/Valve.vue
@@ -52,6 +52,7 @@ export default class Valve extends PartComponent {
       :reversed="reversed"
       path="M50,29H0"
     />
+    <rect fill="red" fill-opacity="0" x="0" y="0" width="50" height="50"/>
   </g>
 </template>
 

--- a/src/plugins/spark/features/ProcessView/parts/Valve.vue
+++ b/src/plugins/spark/features/ProcessView/parts/Valve.vue
@@ -34,13 +34,17 @@ export default class Valve extends PartComponent {
       <line v-if="closed" y1="25" x2="19" y2="25"/>
       <line v-if="closed" x1="31" y1="25" x2="50" y2="25"/>
     </g>
-    <g
-      key="valve-inner"
-      :class="['fill', 'outline', 'inner', closed ? 'closed' : '']"
-      transform-origin="25 25"
-    >
-      <path d="M39.4,21C37.2,13,29,8.3,21,10.5c-5.1,1.4-9.1,5.4-10.5,10.5H39.4z"/>
-      <path d="M10.5,29C12.7,37,21,41.6,29,39.4C34,38,38,34,39.4,29H10.5z"/>
+    <g transform="translate(25, 25)">
+      <g
+        key="valve-inner"
+        :transform="`rotate(${closed ? '90' : '0'})`"
+        class="fill outline inner"
+      >
+        <g transform="translate(-25, -25)">
+          <path d="M39.4,21C37.2,13,29,8.3,21,10.5c-5.1,1.4-9.1,5.4-10.5,10.5H39.4z"/>
+          <path d="M10.5,29C12.7,37,21,41.6,29,39.4C34,38,38,34,39.4,29H10.5z"/>
+        </g>
+      </g>
     </g>
     <AnimatedArrows
       v-if="flowing && !closed"
@@ -55,12 +59,5 @@ export default class Valve extends PartComponent {
 <style scoped>
 .ProcessViewPart {
   cursor: pointer;
-}
-
-.inner {
-  transition: all 0.5s ease;
-}
-.closed {
-  transform: rotate(90deg);
 }
 </style>

--- a/src/plugins/spark/features/ProcessView/parts/Valve.vue
+++ b/src/plugins/spark/features/ProcessView/parts/Valve.vue
@@ -19,28 +19,36 @@ export default class Valve extends PartComponent {
   get reversed() {
     return this.flowOnAngle(RIGHT) > 0;
   }
+
 }
 </script>
 
 <template>
-  <div class="clickable" @click="toggleClosed">
-    <SVGRoot>
-      <g class="outline">
-        <path d="M0,21h10.5c1.4-5.1,5.4-9.1,10.5-10.5C29,8.3,37.2,13,39.4,21h0.1H50"/>
-        <path d="M0,29h10.5h0C12.7,37,21,41.6,29,39.4C34,38,38,34,39.4,29h0.1H50"/>
-      </g>
-      <g v-if="liquid" :stroke="liquidColor" class="liquid">
-        <line v-if="!closed" y1="25" x2="50" y2="25"/>
-        <line v-if="closed" y1="25" x2="19" y2="25"/>
-        <line v-if="closed" x1="31" y1="25" x2="50" y2="25"/>
-      </g>
-      <g :class="{ outline: true, fill: true, valve: true, closed }">
-        <path d="M39.4,21C37.2,13,29,8.3,21,10.5c-5.1,1.4-9.1,5.4-10.5,10.5H39.4z"/>
-        <path d="M10.5,29C12.7,37,21,41.6,29,39.4C34,38,38,34,39.4,29H10.5z"/>
-      </g>
-      <AnimatedArrows v-if="flowing && !closed" :reversed="reversed" path="M50,29H0"/>
-    </SVGRoot>
-  </div>
+  <g class="valve clickable" @click="toggleClosed">
+    <g key="valve-outer" class="outline">
+      <path d="M0,21h10.5c1.4-5.1,5.4-9.1,10.5-10.5C29,8.3,37.2,13,39.4,21h0.1H50"/>
+      <path d="M0,29h10.5h0C12.7,37,21,41.6,29,39.4C34,38,38,34,39.4,29h0.1H50"/>
+    </g>
+    <g v-if="liquid" key="liquid" :stroke="liquidColor" class="liquid">
+      <line v-if="!closed" y1="25" x2="50" y2="25"/>
+      <line v-if="closed" y1="25" x2="19" y2="25"/>
+      <line v-if="closed" x1="31" y1="25" x2="50" y2="25"/>
+    </g>
+    <g
+      key="valve-inner"
+      :class="['fill', 'outline', 'inner', closed ? 'closed' : '']"
+      transform-origin="25 25"
+    >
+      <path d="M39.4,21C37.2,13,29,8.3,21,10.5c-5.1,1.4-9.1,5.4-10.5,10.5H39.4z"/>
+      <path d="M10.5,29C12.7,37,21,41.6,29,39.4C34,38,38,34,39.4,29H10.5z"/>
+    </g>
+    <AnimatedArrows
+      v-if="flowing && !closed"
+      key="valve-arrows"
+      :reversed="reversed"
+      path="M50,29H0"
+    />
+  </g>
 </template>
 
 
@@ -49,12 +57,9 @@ export default class Valve extends PartComponent {
   cursor: pointer;
 }
 
-.valve {
-  transform-origin: 50% 50%;
-  transition: transform 0.5s ease;
-  transform: rotate(0deg);
+.inner {
+  transition: all 0.5s ease;
 }
-
 .closed {
   transform: rotate(90deg);
 }

--- a/src/plugins/spark/features/ProcessView/parts/Valve.vue
+++ b/src/plugins/spark/features/ProcessView/parts/Valve.vue
@@ -16,8 +16,8 @@ export default class Valve extends PartComponent {
     };
   }
 
-  get reversed() {
-    return this.flowOnAngle(RIGHT) > 0;
+  get flowSpeed(){
+    return this.flow[RIGHT];
   }
 
 }
@@ -47,10 +47,10 @@ export default class Valve extends PartComponent {
       </g>
     </g>
     <AnimatedArrows
-      v-if="flowing && !closed"
+      v-if="flowSpeed"
       key="valve-arrows"
-      :reversed="reversed"
-      path="M50,29H0"
+      :speed="flowSpeed"
+      path="M0,25H50"
     />
     <rect fill="red" fill-opacity="0" x="0" y="0" width="50" height="50"/>
   </g>

--- a/src/plugins/spark/features/ProcessView/state.d.ts
+++ b/src/plugins/spark/features/ProcessView/state.d.ts
@@ -30,6 +30,7 @@ export interface ComponentConstructor extends VueConstructor {
   isSource: boolean;
   isBridge: boolean;
   cards: string[];
+  size: (part: PersistentPart) => [number, number];
   transitions: (part: PersistentPart) => Transitions;
 }
 


### PR DESCRIPTION
- Render all components as groups inside a single SVG instead of separate SVGs.
- Make flow arrow speed dependent on flow
- Firefox doesn't support transform-origin on svg elements, so a workaround has been found in translate to 0,0 before rotate and back afterwards.
- To make SVGs easier to click, add a rect with fill opacity 0 (pointer-events bbox not supported in most browsers)