### PR TITLE
display version in prod; allow dashboard id change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ yarn-error.log*
 *.sln
 
 influxdb/
+
+src/build-env.json

--- a/dev/reset_datastore.js
+++ b/dev/reset_datastore.js
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require('fs');
 const request = require('request-promise-native');
 require('dotenv').config({ path: '.env.development' });
+/* eslint-enable */
 
 // Ignore errors about our self-signed certificate
 process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;
@@ -83,7 +85,7 @@ const resetDatastore = async () => {
 
 resetDatastore()
   .then(() => {
-    console.log(`Succesfully reset datastore`);
+    console.log('Succesfully reset datastore');
   })
   .catch((e) => {
     console.log(e);

--- a/dev/reset_spark.js
+++ b/dev/reset_spark.js
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require('fs');
 const request = require('request-promise-native');
-require('dotenv').config({path: '.env.development'});
+require('dotenv').config({ path: '.env.development' });
+/* eslint-enable */
 
 // Ignore errors about our self-signed certificate
 process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = 0;
@@ -31,9 +33,9 @@ const resetObjects = async () => {
 };
 
 resetObjects()
-    .then(() => {
-      console.log(`Succesfully reset objects for ${service}`);
-    })
-    .catch((e) => {
-      console.log(e);
-    });
+  .then(() => {
+    console.log(`Succesfully reset objects for ${service}`);
+  })
+  .catch((e) => {
+    console.log(e);
+  });

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -3,6 +3,11 @@ declare module '*.vue' {
   export default Vue;
 }
 
+declare module '*.json' {
+  const value: any;
+  export default value;
+}
+
 declare module 'quasar';
 declare module 'portal-vue';
 declare module 'vuedraggable';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "strict": true,
     "jsx": "preserve",
     "importHelpers": true,
+    "resolveJsonModule": true,
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "esModuleInterop": true,

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,7 @@
-// eslint-disable-next-line @typescript-eslint/no-var-requires
+/* eslint-disable @typescript-eslint/no-var-requires */
 const { gitDescribeSync } = require('git-describe');
+const fs = require('fs');
+/* eslint-enable */
 
 module.exports = {
   pluginOptions: {
@@ -55,12 +57,14 @@ module.exports = {
       .plugins
       .delete('fork-ts-checker');
 
-    // Set process.env.GIT_VERSION to git version
+    // Write git version to a file that can be imported
+    // src/build-env.json is gitignored, and will be replaced every time
     config
       .plugin('define')
       .tap((args) => {
         const gitInfo = gitDescribeSync(__dirname, { match: '[0-9]*' });
-        args[0]['process.env'].GIT_VERSION = `"${gitInfo.semverString}"`;
+        const version = gitInfo.semverString;
+        fs.writeFileSync('src/build-env.json', JSON.stringify({ version }));
         return args;
       });
   },


### PR DESCRIPTION
Resolves #461 

- Changed the edit buttons in the left drawer to a dropdown button
- Now able to change both dashboard ID and title
- vue.config.js generates `src/build-env.json`, containing the git version string. Unlike changing process.env, this approach works in both develop and production environments.