### PR TITLE
Restyled widgets with caption labels above fields

### DIFF
--- a/src/components/Graph/GraphDisplay.vue
+++ b/src/components/Graph/GraphDisplay.vue
@@ -114,7 +114,7 @@ export default class GraphDisplay extends Vue {
   fill: rgba(255, 255, 255, 1);
 }
 
-/deep .xy2 {
+/deep/ .xy2 {
   color: green;
 }
 </style>

--- a/src/components/PopupEdit/InputPopupEdit.vue
+++ b/src/components/PopupEdit/InputPopupEdit.vue
@@ -31,7 +31,17 @@ import { round, truncate } from '@/helpers/functional';
   },
 })
 export default class InputPopupEdit extends Vue {
-  placeholder = NaN; // must not equal clear-value
+  placeholder: any = null;
+  get value() {
+    if (this.placeholder === null) {
+      this.placeholder = this.$props.field;
+    }
+    return this.placeholder;
+  }
+  set value(v: any) {
+    this.placeholder = this.$props.type === 'number' ? +v : v;
+  }
+
   $refs!: {
     input: any;
   }
@@ -53,13 +63,8 @@ export default class InputPopupEdit extends Vue {
     return val;
   }
 
-  startEdit() {
-    this.placeholder = this.$props.field;
-    // this.$nextTick(() => this.$refs.input.select());
-  }
-
   endEdit() {
-    this.$props.change(this.placeholder);
+    this.$props.change(this.value);
   }
 }
 </script>
@@ -74,11 +79,10 @@ export default class InputPopupEdit extends Vue {
     <q-popup-edit
       :disable="$attrs.disabled"
       :title="$props.label"
-      v-model="placeholder"
+      v-model="value"
       label-set="apply"
       buttons
       persistent
-      @show="startEdit"
       @save="endEdit"
     >
       <div class="help-text text-weight-light q-my-md">
@@ -88,9 +92,11 @@ export default class InputPopupEdit extends Vue {
         ref="input"
         :clearable="$props.clearable"
         :type="$props.type"
-        v-model="placeholder"
+        v-model="value"
         step="any"
         dark
+        autofocus
+        input-style="font-size: 170%"
       />
     </q-popup-edit>
   </div>

--- a/src/components/PopupEdit/LinkPopupEdit.vue
+++ b/src/components/PopupEdit/LinkPopupEdit.vue
@@ -30,28 +30,26 @@ import Component from 'vue-class-component';
   },
 })
 export default class LinkPopupEdit extends Vue {
-  placeholder = ''; // must not equal clear-value
+  get value(): string | null {
+    return this.$props.field.id;
+  }
+
+  set value(v: string | null) {
+    this.$props.change(new Link(v, this.$props.field.type));
+  }
 
   get linkOptions() {
-    const compatible = compatibleBlocks(this.$store, this.$props.serviceId);
-    return (compatible[this.$props.field.type || ''] || [])
-      .map(id => ({
-        label: id,
-        value: id,
-      }));
+    const compatibleTable = compatibleBlocks(this.$store, this.$props.serviceId);
+    const compatible = compatibleTable[this.$props.field.type || ''] || [];
+    return compatible;
   }
 
   get displayValue() {
-    return this.$props.field.id || 'click to assign';
+    return this.value || 'click to assign';
   }
 
   startEdit() {
-    this.placeholder = this.$props.field.id;
     fetchCompatibleBlocks(this.$store, this.$props.serviceId, this.$props.field.type);
-  }
-
-  endEdit() {
-    this.$props.change(new Link(this.placeholder, this.$props.field.type));
   }
 }
 </script>
@@ -60,41 +58,42 @@ export default class LinkPopupEdit extends Vue {
   <div>
     <component :is="$props.tag" class="editable clickable" @click="startEdit">
       {{ displayValue | truncated }}
-      <q-menu>
+      <q-menu content-style="overflow: visible">
         <q-item dark>
           <q-item-section class="help-text text-weight-light">
             <big>{{ $props.label }}</big>
             <slot/>
           </q-item-section>
         </q-item>
+
         <q-item dark>
           <q-item-section>
-            <q-btn
-              v-close-popup
-              icon="clear"
-              label="clear"
-              flat
-              @click="() => { placeholder = null; endEdit() }"
-            />
+            <q-select
+              v-model="value"
+              :options="linkOptions"
+              :label="`${$props.label} block`"
+              dark
+              options-dark
+            >
+              <template v-slot:no-option>
+                <q-item dark>
+                  <q-item-section class="text-grey">No results</q-item-section>
+                </q-item>
+              </template>
+              <template v-slot:append>
+                <q-btn icon="mdi-close-circle" flat round size="sm" @click="value=null">
+                  <q-tooltip>
+                    <span>
+                      Set {{ $props.label }} to
+                      <i>None</i>
+                    </span>
+                  </q-tooltip>
+                </q-btn>
+              </template>
+            </q-select>
           </q-item-section>
-        </q-item>
-        <q-separator dark inset/>
-        <q-item
-          v-close-popup
-          v-for="opt in linkOptions"
-          :key="opt.value"
-          :active="opt.value === placeholder"
-          clickable
-          dark
-          @click="() => { placeholder = opt.value; endEdit() }"
-        >
-          <q-item-section>{{ opt.label }}</q-item-section>
         </q-item>
       </q-menu>
     </component>
   </div>
 </template>
-
-<style lang="stylus" scoped>
-@import './popups.styl';
-</style>

--- a/src/components/PopupEdit/LinkPopupEdit.vue
+++ b/src/components/PopupEdit/LinkPopupEdit.vue
@@ -30,12 +30,16 @@ import Component from 'vue-class-component';
   },
 })
 export default class LinkPopupEdit extends Vue {
+  placeholder: string | null = '';
   get value(): string | null {
-    return this.$props.field.id;
+    if (this.placeholder === '') {
+      this.placeholder = this.$props.field.id;
+    }
+    return this.placeholder;
   }
 
   set value(v: string | null) {
-    this.$props.change(new Link(v, this.$props.field.type));
+    this.placeholder = v;
   }
 
   get linkOptions() {
@@ -45,11 +49,15 @@ export default class LinkPopupEdit extends Vue {
   }
 
   get displayValue() {
-    return this.value || 'click to assign';
+    return this.$props.field || 'click to assign';
   }
 
   startEdit() {
     fetchCompatibleBlocks(this.$store, this.$props.serviceId, this.$props.field.type);
+  }
+
+  endEdit() {
+    this.$props.change(new Link(this.value, this.$props.field.type));
   }
 }
 </script>
@@ -91,6 +99,15 @@ export default class LinkPopupEdit extends Vue {
                 </q-btn>
               </template>
             </q-select>
+          </q-item-section>
+        </q-item>
+        <q-item dark>
+          <q-item-section/>
+          <q-item-section side>
+            <q-btn v-close-popup dark flat color="primary" label="Cancel"/>
+          </q-item-section>
+          <q-item-section side>
+            <q-btn v-close-popup dark flat color="primary" label="Apply" @click="endEdit()"/>
           </q-item-section>
         </q-item>
       </q-menu>

--- a/src/components/PopupEdit/SelectPopupEdit.vue
+++ b/src/components/PopupEdit/SelectPopupEdit.vue
@@ -34,21 +34,17 @@ import Component from 'vue-class-component';
   },
 })
 export default class SelectPopupEdit extends Vue {
-  plc = NaN;
+  placeholder: any = NaN;
 
-  get placeholder() {
-    // Ensures that value always changes during edit
-    // Placeholder must not equal clear-value
-    if (Number.isNaN(this.plc)) {
-      return this.$props.multiple
-        ? [undefined]
-        : undefined;
+  get selected(): any {
+    if (Number.isNaN(this.placeholder)) {
+      this.placeholder = this.$props.options.find(v => v.value === this.$props.field) || null;
     }
-    return this.plc;
+    return this.placeholder;
   }
 
-  set placeholder(v: any) {
-    this.plc = v;
+  set selected(v: any) {
+    this.placeholder = v;
   }
 
   get displayValue() {
@@ -65,44 +61,53 @@ export default class SelectPopupEdit extends Vue {
       .label;
   }
 
-  startEdit() {
-    this.placeholder = this.$props.field;
-  }
-
-  endEdit(v: any) {
-    this.placeholder = v;
-    this.$props.change(this.placeholder);
+  endEdit() {
+    this.$props.change(this.selected === null ? null : this.selected.value);
   }
 }
 </script>
 
 <template>
   <div>
-    <component :is="$props.tag" class="editable clickable" @click="startEdit">
+    <component :is="$props.tag" class="editable">
       {{ displayValue | truncated }}
-      <q-menu>
+      <q-menu content-style="overflow: visible">
         <q-item dark>
           <q-item-section class="help-text text-weight-light">
             <big>{{ $props.label }}</big>
             <slot/>
           </q-item-section>
         </q-item>
-        <q-item v-if="$props.clearable" dark>
+        <q-item dark>
           <q-item-section>
-            <q-btn v-close-popup icon="clear" label="clear" flat @click="endEdit(null)"/>
+            <q-select
+              v-model="selected"
+              :options="$props.options"
+              dark
+              options-dark
+              option-label="label"
+            >
+              <template v-slot:append v-if="clearable">
+                <q-btn icon="mdi-close-circle" flat round size="sm" @click.stop="selected = null">
+                  <q-tooltip>
+                    <span>
+                      Set {{ $props.label }} to
+                      <i>None</i>
+                    </span>
+                  </q-tooltip>
+                </q-btn>
+              </template>
+            </q-select>
           </q-item-section>
         </q-item>
-        <q-separator dark inset/>
-        <q-item
-          v-close-popup
-          v-for="opt in $props.options"
-          :key="String(opt.value)"
-          :active="opt.value === placeholder"
-          clickable
-          dark
-          @click="endEdit(opt.value)"
-        >
-          <q-item-section>{{ opt.label }}</q-item-section>
+        <q-item dark>
+          <q-item-section/>
+          <q-item-section side>
+            <q-btn v-close-popup dark flat color="primary" label="Cancel"/>
+          </q-item-section>
+          <q-item-section side>
+            <q-btn v-close-popup dark flat color="primary" label="Apply" @click="endEdit()"/>
+          </q-item-section>
         </q-item>
       </q-menu>
     </component>

--- a/src/components/PopupEdit/TimeUnitPopupEdit.vue
+++ b/src/components/PopupEdit/TimeUnitPopupEdit.vue
@@ -2,7 +2,7 @@
 import { Unit } from '@/helpers/units';
 import Vue from 'vue';
 import Component from 'vue-class-component';
-import { unitDurationString } from '@/helpers/functional';
+import { durationString, unitDurationString } from '@/helpers/functional';
 import parseDuration from 'parse-duration';
 
 @Component({
@@ -26,14 +26,21 @@ import parseDuration from 'parse-duration';
   },
 })
 export default class TimeUnitPopupEdit extends Vue {
-  placeholder: any = NaN; // must not equal clear-value
+  placeholder: string | null = null;
 
-  startEdit() {
-    this.placeholder = unitDurationString(this.$props.field);
+  get value(): string {
+    if (this.placeholder === null) {
+      this.placeholder = unitDurationString(this.$props.field);
+    }
+    return this.placeholder;
+  }
+
+  set value(v: string) {
+    this.placeholder = v;
   }
 
   endEdit() {
-    const fieldCopy = new Unit(parseDuration(this.placeholder), 'ms');
+    const fieldCopy = new Unit(parseDuration(this.value), 'ms');
     this.$props.change(fieldCopy);
   }
 }
@@ -44,17 +51,16 @@ export default class TimeUnitPopupEdit extends Vue {
     <component :is="$props.tag" class="editable">{{ this.$props.field | unitDuration }}</component>
     <q-popup-edit
       :title="this.$props.label"
-      v-model="placeholder"
+      v-model.lazy="value"
       label-set="apply"
       buttons
       persistent
-      @show="startEdit"
       @save="endEdit"
     >
       <div class="help-text text-weight-light q-my-md">
         <slot/>
       </div>
-      <q-input v-model="placeholder" dark/>
+      <q-input v-model.lazy="value" dark/>
     </q-popup-edit>
   </div>
 </template>

--- a/src/components/PopupEdit/UnitPopupEdit.vue
+++ b/src/components/PopupEdit/UnitPopupEdit.vue
@@ -28,17 +28,17 @@ import Component from 'vue-class-component';
   },
 })
 export default class UnitPopupEdit extends Vue {
-  placeholder = NaN; // must not equal clear-value
-  $refs!: {
-    input: any;
+  placeholder: number | null = null;
+
+  get value() {
+    if (this.placeholder === null) {
+      this.placeholder = this.$props.field.val;
+    }
+    return this.placeholder;
   }
 
-  get initialValue() {
-    return this.$props.field.value;
-  }
-
-  startEdit() {
-    this.placeholder = this.initialValue;
+  set value(v: any) {
+    this.placeholder = +v;
   }
 
   endEdit() {
@@ -58,11 +58,10 @@ export default class UnitPopupEdit extends Vue {
     />
     <q-popup-edit
       :title="this.$props.label"
-      v-model="placeholder"
+      v-model="value"
       label-set="apply"
       buttons
       persistent
-      @show="startEdit"
       @save="endEdit"
     >
       <div class="help-text text-weight-light q-my-md">
@@ -70,7 +69,7 @@ export default class UnitPopupEdit extends Vue {
       </div>
       <q-input
         ref="input"
-        v-model="placeholder"
+        v-model="value"
         input-style="font-size: 170%"
         type="number"
         step="any"

--- a/src/components/PopupEdit/UnitPopupEdit.vue
+++ b/src/components/PopupEdit/UnitPopupEdit.vue
@@ -33,10 +33,6 @@ export default class UnitPopupEdit extends Vue {
     input: any;
   }
 
-  get notation() {
-    return this.$props.field.notation;
-  }
-
   get initialValue() {
     return this.$props.field.value;
   }
@@ -54,8 +50,12 @@ export default class UnitPopupEdit extends Vue {
 
 <template>
   <div>
-    <component :is="$props.tag" class="editable">{{ this.$props.field.value | round }}</component>
-    <component :is="$props.unitTag" class="q-ml-xs">{{ this.$props.field.notation }}</component>
+    <UnitField
+      :tag="$props.tag"
+      :unit-tag="$props.unitTag"
+      :field="$props.field"
+      tag-class="editable"
+    />
     <q-popup-edit
       :title="this.$props.label"
       v-model="placeholder"
@@ -68,8 +68,15 @@ export default class UnitPopupEdit extends Vue {
       <div class="help-text text-weight-light q-my-md">
         <slot/>
       </div>
-      <q-input ref="input" v-model="placeholder" type="number" step="any" dark>
-        <template v-slot:append>{{ notation }}</template>
+      <q-input
+        ref="input"
+        v-model="placeholder"
+        input-style="font-size: 170%"
+        type="number"
+        step="any"
+        dark
+      >
+        <template v-slot:append>{{ field.notation }}</template>
       </q-input>
     </q-popup-edit>
   </div>

--- a/src/components/PopupEdit/UnitPopupEdit.vue
+++ b/src/components/PopupEdit/UnitPopupEdit.vue
@@ -21,6 +21,10 @@ import Component from 'vue-class-component';
       type: String,
       default: 'big',
     },
+    unitTag: {
+      type: String,
+      default: 'span',
+    },
   },
 })
 export default class UnitPopupEdit extends Vue {
@@ -50,7 +54,8 @@ export default class UnitPopupEdit extends Vue {
 
 <template>
   <div>
-    <component :is="$props.tag" class="editable">{{ this.$props.field | unit }}</component>
+    <component :is="$props.tag" class="editable">{{ this.$props.field.value | round }}</component>
+    <component :is="$props.unitTag" class="q-ml-xs">{{ this.$props.field.notation }}</component>
     <q-popup-edit
       :title="this.$props.label"
       v-model="placeholder"

--- a/src/components/UnitField.vue
+++ b/src/components/UnitField.vue
@@ -1,0 +1,38 @@
+<script lang="ts">
+import Vue from 'vue';
+import Component from 'vue-class-component';
+
+@Component({
+  props: {
+    field: {
+      type: Object,
+      required: true,
+    },
+    tag: {
+      type: String,
+      default: 'big',
+    },
+    tagClass: {
+      type: String,
+      default: '',
+    },
+    unitTag: {
+      type: String,
+      default: 'span',
+    },
+  },
+})
+export default class UnitField extends Vue {
+}
+</script>
+
+<template>
+  <div>
+    <component :is="$props.tag" :class="$props.tagClass">{{ this.$props.field.value | round }}</component>
+    <component
+      v-if="$props.field.value !== null"
+      :is="$props.unitTag"
+      class="q-ml-xs"
+    >{{ this.$props.field.notation }}</component>
+  </div>
+</template>

--- a/src/helpers/functional.ts
+++ b/src/helpers/functional.ts
@@ -115,7 +115,7 @@ export const round =
     if (value === null || value === undefined) {
       return '--.--';
     }
-    return +value.toFixed(2);
+    return (+value).toFixed(2);
   };
 
 export const truncate =

--- a/src/helpers/units/Unit.ts
+++ b/src/helpers/units/Unit.ts
@@ -18,7 +18,7 @@ export default class Unit {
   public notation: string;
 
   public constructor(value: number | null, unit: string) {
-    this.val = Number(value);
+    this.val = value;
     this.unit = unit;
     this.notation = prettify(this.unit);
   }

--- a/src/plugins/spark/components/BlockSettings.vue
+++ b/src/plugins/spark/components/BlockSettings.vue
@@ -24,8 +24,8 @@ export default class BlockSettings extends BlockForm {
 <template>
   <q-list>
     <q-item dark>
-      <q-item-section>Block ID</q-item-section>
       <q-item-section>
+        <q-item-label caption>Block ID</q-item-label>
         <InputPopupEdit
           :field="block.id"
           :change="$props.onChangeBlockId"
@@ -33,18 +33,18 @@ export default class BlockSettings extends BlockForm {
           label="Block ID"
         />
       </q-item-section>
-    </q-item>
-    <q-item dark>
-      <q-item-section>Block Type</q-item-section>
-      <q-item-section>{{ block.type }}</q-item-section>
-    </q-item>
-    <q-item dark>
-      <q-item-section>Part of service</q-item-section>
-      <q-item-section>{{ serviceId }}</q-item-section>
-    </q-item>
-    <q-item dark>
-      <q-item-section>Active in groups</q-item-section>
       <q-item-section>
+        <q-item-label caption>Block Type</q-item-label>
+        <span>{{ block.type }}</span>
+      </q-item-section>
+    </q-item>
+    <q-item dark>
+      <q-item-section>
+        <q-item-label caption>Part of service</q-item-label>
+        <span>{{ serviceId }}</span>
+      </q-item-section>
+      <q-item-section>
+        <q-item-label caption>Active in groups</q-item-label>
         <GroupsPopupEdit
           :field="block.groups"
           :service-id="serviceId"
@@ -54,13 +54,13 @@ export default class BlockSettings extends BlockForm {
       </q-item-section>
     </q-item>
     <q-item v-if="$props.presetsData.length > 0" dark>
-      <q-item-section>Apply preset</q-item-section>
       <q-item-section>
+        <q-item-label caption>Apply block settings preset</q-item-label>
         <SelectPopupEdit
           :field="block.data"
           :options="$props.presetsData"
           :change="callAndSaveBlock(applyPreset)"
-          label="preset"
+          label="Select a preset"
           tag="span"
         />
       </q-item-section>

--- a/src/plugins/spark/components/Constraints/AnalogConstraints.vue
+++ b/src/plugins/spark/components/Constraints/AnalogConstraints.vue
@@ -87,7 +87,7 @@ export default class AnalogConstraints extends Constraints {
             />
           </q-item-section>
           <q-item-section side>
-            <q-btn icon="delete" @click="removeConstraint(idx); saveConstraints();"/>
+            <q-btn icon="delete" flat @click="removeConstraint(idx); saveConstraints();"/>
           </q-item-section>
         </template>
       </q-item>
@@ -95,7 +95,6 @@ export default class AnalogConstraints extends Constraints {
         <q-item-section side>Add constraint</q-item-section>
         <q-item-section v-for="opt in constraintOptions" :key="opt.value">
           <q-btn
-            v-close-popup
             :label="opt.label"
             outline
             @click="constraints.push(createConstraint(opt.value)); saveConstraints();"

--- a/src/plugins/spark/components/Constraints/AnalogConstraints.vue
+++ b/src/plugins/spark/components/Constraints/AnalogConstraints.vue
@@ -45,65 +45,65 @@ export default class AnalogConstraints extends Constraints {
 </script>
 
 <template>
-  <q-list separator dark>
-    <q-item v-for="(cinfo, idx) in constraints" :key="idx" dark>
-      <template v-if="readonly">
-        <q-item-section :class="{ limiting: cinfo.limiting }" side>{{ label(cinfo.key) }}</q-item-section>
-        <q-item-section>{{ ( cinfo.key === 'balanced' ? cinfo.value.granted : cinfo.value) | unit }}</q-item-section>
-      </template>
-      <template v-else>
-        <q-item-section side>
-          <SelectPopupEdit
-            :options="constraintOptions"
-            :field="cinfo.key"
-            :change="callAndSaveConstraints(k => constraints[idx] = createConstraint(k))"
-            clearable
-            label="Constraint type"
-            tag="span"
+  <div>
+    <q-item-label v-if="constraints.length !== 0 && readonly" caption>Constraints</q-item-label>
+    <q-list dark>
+      <q-item v-for="(cinfo, idx) in constraints" :key="idx" dark dense>
+        <template v-if="readonly">
+          <q-item-section :class="{ limiting: cinfo.limiting }">{{ label(cinfo.key) }}</q-item-section>
+          <q-item-section>{{ ( cinfo.key === 'balanced' ? cinfo.value.granted : cinfo.value) | unit }}</q-item-section>
+        </template>
+        <template v-else>
+          <q-item-section>
+            <SelectPopupEdit
+              :options="constraintOptions"
+              :field="cinfo.key"
+              :change="callAndSaveConstraints(k => constraints[idx] = createConstraint(k))"
+              clearable
+              label="Constraint type"
+              tag="span"
+            />
+          </q-item-section>
+          <q-item-section>
+            <component
+              v-if="cinfo.key === 'balanced'"
+              :is="fieldType(cinfo.key)"
+              :service-id="serviceId"
+              :field="cinfo.value.balancerId"
+              :change="callAndSaveConstraints(v => cinfo.value.balancerId = v)"
+              label="Constraint value"
+              type="number"
+              tag="span"
+            />
+            <component
+              v-else
+              :is="fieldType(cinfo.key)"
+              :service-id="serviceId"
+              :field="cinfo.value"
+              :change="callAndSaveConstraints(v => cinfo.value = v)"
+              label="Constraint value"
+              type="number"
+              tag="span"
+            />
+          </q-item-section>
+          <q-item-section side>
+            <q-btn icon="delete" @click="removeConstraint(idx); saveConstraints();"/>
+          </q-item-section>
+        </template>
+      </q-item>
+      <q-item v-if="!readonly" dark>
+        <q-item-section side>Add constraint</q-item-section>
+        <q-item-section v-for="opt in constraintOptions" :key="opt.value">
+          <q-btn
+            v-close-popup
+            :label="opt.label"
+            outline
+            @click="constraints.push(createConstraint(opt.value)); saveConstraints();"
           />
         </q-item-section>
-        <q-item-section>
-          <component
-            v-if="cinfo.key === 'balanced'"
-            :is="fieldType(cinfo.key)"
-            :service-id="serviceId"
-            :field="cinfo.value.balancerId"
-            :change="callAndSaveConstraints(v => cinfo.value.balancerId = v)"
-            label="Constraint value"
-            type="number"
-            tag="span"
-          />
-          <component
-            v-else
-            :is="fieldType(cinfo.key)"
-            :service-id="serviceId"
-            :field="cinfo.value"
-            :change="callAndSaveConstraints(v => cinfo.value = v)"
-            label="Constraint value"
-            type="number"
-            tag="span"
-          />
-        </q-item-section>
-        <q-item-section side>
-          <q-btn icon="delete" @click="removeConstraint(idx); saveConstraints();"/>
-        </q-item-section>
-      </template>
-    </q-item>
-    <q-item v-if="readonly && constraints.length === 0" dark>
-      <q-item-section>No Constraints</q-item-section>
-    </q-item>
-    <q-item v-if="!readonly" dark>
-      <q-item-section side>Add constraint</q-item-section>
-      <q-item-section v-for="opt in constraintOptions" :key="opt.value">
-        <q-btn
-          v-close-popup
-          :label="opt.label"
-          outline
-          @click="constraints.push(createConstraint(opt.value)); saveConstraints();"
-        />
-      </q-item-section>
-    </q-item>
-  </q-list>
+      </q-item>
+    </q-list>
+  </div>
 </template>
 
 <style scoped>

--- a/src/plugins/spark/components/Constraints/DigitalConstraints.vue
+++ b/src/plugins/spark/components/Constraints/DigitalConstraints.vue
@@ -85,7 +85,6 @@ export default class DigitalConstraints extends Constraints {
         <q-item-section side>Add constraint</q-item-section>
         <q-item-section v-for="opt in constraintOptions" :key="opt.value">
           <q-btn
-            v-close-popup
             :label="opt.label"
             outline
             @click="constraints.push(createConstraint(opt.value)); saveConstraints();"

--- a/src/plugins/spark/components/Constraints/DigitalConstraints.vue
+++ b/src/plugins/spark/components/Constraints/DigitalConstraints.vue
@@ -46,54 +46,54 @@ export default class DigitalConstraints extends Constraints {
 </script>
 
 <template>
-  <q-list separator dark>
-    <q-item v-for="(cinfo, idx) in constraints" :key="idx" dark>
-      <template v-if="readonly">
-        <q-item-section :class="{ limiting: cinfo.limiting }" side>{{ label(cinfo.key) }}</q-item-section>
-        <q-item-section>{{ cinfo.value | unit }}</q-item-section>
-      </template>
-      <template v-else>
-        <q-item-section side>
-          <SelectPopupEdit
-            :options="constraintOptions"
-            :field="cinfo.key"
-            :change="callAndSaveConstraints(k => constraints[idx] = createConstraint(k))"
-            clearable
-            label="Constraint type"
-            tag="span"
+  <div>
+    <q-item-label v-if="constraints.length !== 0 && readonly" caption>Constraints</q-item-label>
+    <q-list dark>
+      <q-item v-for="(cinfo, idx) in constraints" :key="idx" dark>
+        <template v-if="readonly">
+          <q-item-section :class="{ limiting: cinfo.limiting }" side>{{ label(cinfo.key) }}</q-item-section>
+          <q-item-section>{{ cinfo.value | unit }}</q-item-section>
+        </template>
+        <template v-else>
+          <q-item-section side>
+            <SelectPopupEdit
+              :options="constraintOptions"
+              :field="cinfo.key"
+              :change="callAndSaveConstraints(k => constraints[idx] = createConstraint(k))"
+              clearable
+              label="Constraint type"
+              tag="span"
+            />
+          </q-item-section>
+          <q-item-section>
+            <component
+              :is="fieldType(cinfo.key)"
+              :service-id="serviceId"
+              :field="cinfo.value"
+              :change="callAndSaveConstraints(v => cinfo.value = v)"
+              label="Constraint value"
+              type="number"
+              tag="span"
+            />
+          </q-item-section>
+          <q-item-section side>
+            <q-btn icon="delete" flat @click="removeConstraint(idx); saveConstraints();"/>
+          </q-item-section>
+        </template>
+      </q-item>
+      <q-item v-if="!readonly" dark>
+        <q-item-section side>Add constraint</q-item-section>
+        <q-item-section v-for="opt in constraintOptions" :key="opt.value">
+          <q-btn
+            v-close-popup
+            :label="opt.label"
+            outline
+            @click="constraints.push(createConstraint(opt.value)); saveConstraints();"
           />
         </q-item-section>
-        <q-item-section>
-          <component
-            :is="fieldType(cinfo.key)"
-            :service-id="serviceId"
-            :field="cinfo.value"
-            :change="callAndSaveConstraints(v => cinfo.value = v)"
-            label="Constraint value"
-            type="number"
-            tag="span"
-          />
-        </q-item-section>
-        <q-item-section side>
-          <q-btn icon="delete" flat @click="removeConstraint(idx); saveConstraints();"/>
-        </q-item-section>
-      </template>
-    </q-item>
-    <q-item v-if="readonly && constraints.length === 0" dark>
-      <q-item-section>No Constraints</q-item-section>
-    </q-item>
-    <q-item v-if="!readonly" dark>
-      <q-item-section side>Add constraint</q-item-section>
-      <q-item-section v-for="opt in constraintOptions" :key="opt.value">
-        <q-btn
-          v-close-popup
-          :label="opt.label"
-          outline
-          @click="constraints.push(createConstraint(opt.value)); saveConstraints();"
-        />
-      </q-item-section>
-    </q-item>
-  </q-list>
+      </q-item>
+    </q-list>
+  </div>
 </template>
 
 <style scoped>

--- a/src/plugins/spark/components/GroupsPopupEdit.vue
+++ b/src/plugins/spark/components/GroupsPopupEdit.vue
@@ -18,7 +18,7 @@ import Component from 'vue-class-component';
     },
     tag: {
       type: String,
-      default: 'big',
+      default: 'span',
     },
   },
 })

--- a/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockForm.vue
+++ b/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockForm.vue
@@ -28,24 +28,9 @@ export default class ActuatorAnalogMockForm extends BlockForm {
     <q-card-section>
       <q-expansion-item default-opened group="modal" icon="settings" label="Settings">
         <q-item dark>
-          <q-item-section>Supported setting min</q-item-section>
-          <q-item-section>
-            <InputPopupEdit
-              :field="block.data.minSetting"
-              :change="callAndSaveBlock(v => block.data.minSetting = v)"
-              type="number"
-              label="supported setting min"
-            />
-          </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>
-            <div class="column">
-              <span>Setting</span>
-              <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
-            </div>
-          </q-item-section>
-          <q-item-section>
+          <q-item-section style="justify-content: space-between">
+            <q-item-label caption>Setting</q-item-label>
+            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
             <InputPopupEdit
               v-if="!isDriven"
               :field="block.data.setting"
@@ -55,43 +40,46 @@ export default class ActuatorAnalogMockForm extends BlockForm {
             />
             <big v-else>{{ block.data.setting | unit }}</big>
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Supported setting max</q-item-section>
-          <q-item-section>
+          <q-item-section style="justify-content: space-between">
+            <q-item-label caption>Clip to min</q-item-label>
+            <InputPopupEdit
+              :field="block.data.minSetting"
+              :change="callAndSaveBlock(v => block.data.minSetting = v)"
+              type="number"
+              label="Setting min"
+            />
+          </q-item-section>
+          <q-item-section style="justify-content: space-between">
+            <q-item-label caption>Clip to max</q-item-label>
             <InputPopupEdit
               :field="block.data.maxSetting"
               :change="callAndSaveBlock(v => block.data.maxSetting = v)"
               type="number"
-              label="supported setting max"
+              label="Setting max"
             />
           </q-item-section>
         </q-item>
         <q-item dark>
-          <q-item-section>Value min (clipping)</q-item-section>
           <q-item-section>
-            <InputPopupEdit
-              :field="block.data.minValue"
-              :change="callAndSaveBlock(v => block.data.minValue = v)"
-              type="number"
-              label="value min"
-            />
-          </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Value</q-item-section>
-          <q-item-section>
+            <q-item-label caption>Value</q-item-label>
             <big>{{ block.data.value | round }}</big>
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Value max (clipping)</q-item-section>
           <q-item-section>
+            <q-item-label caption>Clip to min</q-item-label>
             <InputPopupEdit
               :field="block.data.minValue"
               :change="callAndSaveBlock(v => block.data.minValue = v)"
               type="number"
-              label="value min"
+              label="Value min"
+            />
+          </q-item-section>
+          <q-item-section>
+            <q-item-label caption>Clip to max</q-item-label>
+            <InputPopupEdit
+              :field="block.data.maxValue"
+              :change="callAndSaveBlock(v => block.data.maxValue = v)"
+              type="number"
+              label="Value max"
             />
           </q-item-section>
         </q-item>

--- a/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockForm.vue
+++ b/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockForm.vue
@@ -28,9 +28,8 @@ export default class ActuatorAnalogMockForm extends BlockForm {
     <q-card-section>
       <q-expansion-item default-opened group="modal" icon="settings" label="Settings">
         <q-item dark>
-          <q-item-section style="justify-content: space-between">
+          <q-item-section style="justify-content: flex-start">
             <q-item-label caption>Setting</q-item-label>
-            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
             <InputPopupEdit
               v-if="!isDriven"
               :field="block.data.setting"
@@ -39,8 +38,9 @@ export default class ActuatorAnalogMockForm extends BlockForm {
               label="target"
             />
             <big v-else>{{ block.data.setting | unit }}</big>
+            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
           </q-item-section>
-          <q-item-section style="justify-content: space-between">
+          <q-item-section style="justify-content: flex-start">
             <q-item-label caption>Clip to min</q-item-label>
             <InputPopupEdit
               :field="block.data.minSetting"
@@ -49,7 +49,7 @@ export default class ActuatorAnalogMockForm extends BlockForm {
               label="Setting min"
             />
           </q-item-section>
-          <q-item-section style="justify-content: space-between">
+          <q-item-section style="justify-content: flex-start">
             <q-item-label caption>Clip to max</q-item-label>
             <InputPopupEdit
               :field="block.data.maxSetting"

--- a/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockForm.vue
+++ b/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockForm.vue
@@ -86,15 +86,11 @@ export default class ActuatorAnalogMockForm extends BlockForm {
       </q-expansion-item>
 
       <q-expansion-item group="modal" icon="mdi-less-than-or-equal" label="Constraints">
-        <q-item dark>
-          <q-item-section>
-            <AnalogConstraints
-              :service-id="block.serviceId"
-              :field="block.data.constrainedBy"
-              :change="callAndSaveBlock(v => block.data.constrainedBy = v)"
-            />
-          </q-item-section>
-        </q-item>
+        <AnalogConstraints
+          :service-id="block.serviceId"
+          :field="block.data.constrainedBy"
+          :change="callAndSaveBlock(v => block.data.constrainedBy = v)"
+        />
       </q-expansion-item>
 
       <q-expansion-item group="modal" icon="mdi-cube" label="Block Settings">

--- a/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockWidget.vue
+++ b/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockWidget.vue
@@ -36,38 +36,34 @@ export default class ActuatorAnalogMockWidget extends BlockWidget {
       </q-item>
       <q-item dark>
         <q-item-section>
-          <div class="column">
-            <span>Setting</span>
-            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
+          <q-item-label caption>Setting</q-item-label>
+          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
+          <div>
+            <InputPopupEdit
+              v-if="!isDriven"
+              :field="block.data.setting"
+              :change="callAndSaveBlock(v => block.data.setting = v)"
+              type="number"
+              label="Setting"
+            />
+            <div v-else>
+              <big>{{ block.data.setting | round }}</big>
+              <small class="q-ml-xs">{{ block.data.error.notation }}</small>
+            </div>
           </div>
         </q-item-section>
         <q-item-section>
-          <InputPopupEdit
-            v-if="!isDriven"
-            :field="block.data.setting"
-            :change="callAndSaveBlock(v => block.data.setting = v)"
-            type="number"
-            label="Setting"
-          />
-          <big v-else>{{ block.data.setting | unit }}</big>
-        </q-item-section>
-      </q-item>
-      <q-item dark>
-        <q-item-section>Value</q-item-section>
-        <q-item-section>
+          <q-item-label caption>Value</q-item-label>
           <big>{{ block.data.value | round }}</big>
         </q-item-section>
       </q-item>
       <q-item dark>
-        <q-item-label>Constraints</q-item-label>
-        <q-item-section>
-          <AnalogConstraints
-            :service-id="serviceId"
-            :field="block.data.constrainedBy"
-            :change="callAndSaveBlock(v => block.data.constrainedBy = v)"
-            readonly
-          />
-        </q-item-section>
+        <AnalogConstraints
+          :service-id="serviceId"
+          :field="block.data.constrainedBy"
+          :change="callAndSaveBlock(v => block.data.constrainedBy = v)"
+          readonly
+        />
       </q-item>
     </q-card-section>
   </q-card>

--- a/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockWidget.vue
+++ b/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockWidget.vue
@@ -35,9 +35,8 @@ export default class ActuatorAnalogMockWidget extends BlockWidget {
         <q-item-section>This Actuator is invalid</q-item-section>
       </q-item>
       <q-item dark>
-        <q-item-section>
+        <q-item-section style="justify-content: flex-start">
           <q-item-label caption>Setting</q-item-label>
-          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
           <div>
             <InputPopupEdit
               v-if="!isDriven"
@@ -52,8 +51,9 @@ export default class ActuatorAnalogMockWidget extends BlockWidget {
               :class="{ darkened: block.data.setting.value === null }"
             />
           </div>
+          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
         </q-item-section>
-        <q-item-section>
+        <q-item-section style="justify-content: flex-start">
           <q-item-label caption>Value</q-item-label>
           <big>{{ block.data.value | round }}</big>
         </q-item-section>

--- a/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockWidget.vue
+++ b/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockWidget.vue
@@ -46,10 +46,11 @@ export default class ActuatorAnalogMockWidget extends BlockWidget {
               type="number"
               label="Setting"
             />
-            <div v-else>
-              <big>{{ block.data.setting | round }}</big>
-              <small class="q-ml-xs">{{ block.data.error.notation }}</small>
-            </div>
+            <UnitField
+              v-else
+              :field="block.data.setting"
+              :class="{ darkened: block.data.setting.value === null }"
+            />
           </div>
         </q-item-section>
         <q-item-section>

--- a/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockWidget.vue
+++ b/src/plugins/spark/features/ActuatorAnalogMock/ActuatorAnalogMockWidget.vue
@@ -59,12 +59,14 @@ export default class ActuatorAnalogMockWidget extends BlockWidget {
         </q-item-section>
       </q-item>
       <q-item dark>
-        <AnalogConstraints
-          :service-id="serviceId"
-          :field="block.data.constrainedBy"
-          :change="callAndSaveBlock(v => block.data.constrainedBy = v)"
-          readonly
-        />
+        <q-item-section>
+          <AnalogConstraints
+            :service-id="serviceId"
+            :field="block.data.constrainedBy"
+            :change="callAndSaveBlock(v => block.data.constrainedBy = v)"
+            readonly
+          />
+        </q-item-section>
       </q-item>
     </q-card-section>
   </q-card>

--- a/src/plugins/spark/features/ActuatorDS2413/ActuatorDS2413Form.vue
+++ b/src/plugins/spark/features/ActuatorDS2413/ActuatorDS2413Form.vue
@@ -53,49 +53,42 @@ export default class ActuatorDS2413Form extends BlockForm {
 <template>
   <q-card dark class="widget-modal">
     <BlockFormToolbar v-if="!$props.embedded" v-bind="$props" :block="block"/>
-
     <q-card-section>
       <q-expansion-item default-opened group="modal" icon="settings" label="Settings">
         <q-item dark>
-          <q-item-section>DS2413 Block</q-item-section>
           <q-item-section>
+            <q-item-label caption>DS2413 target Block</q-item-label>
             <LinkPopupEdit
               :field="block.data.hwDevice"
               :service-id="serviceId"
               :change="callAndSaveBlock(v => block.data.hwDevice = v)"
               label="DS2413 Block"
+              tag="span"
             />
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>DS2413 Channel</q-item-section>
           <q-item-section>
+            <q-item-label caption>DS2413 Channel</q-item-label>
             <SelectPopupEdit
               :field="block.data.channel"
               :options="channelOpts"
               :change="callAndSaveBlock(v => block.data.channel = v)"
               label="DS2413 Channel"
+              tag="span"
             />
           </q-item-section>
         </q-item>
         <q-item dark>
-          <q-item-section>
-            <div class="column">
-              <span>State</span>
-              <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
-            </div>
-          </q-item-section>
-          <q-item-section>
+          <q-item-section style="justify-content: flex-start">
+            <q-item-label caption>State</q-item-label>
             <ActuatorState
               :disable="isDriven"
               :field="block.data.state"
               :change="callAndSaveBlock(v => block.data.state = v)"
             />
+            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Invert</q-item-section>
-          <q-item-section>
+          <q-item-section style="justify-content: flex-start">
+            <q-item-label caption>Invert</q-item-label>
             <q-toggle
               :value="block.data.invert"
               @input="v => { block.data.invert = v; saveBlock(); }"

--- a/src/plugins/spark/features/ActuatorDS2413/ActuatorDS2413Widget.vue
+++ b/src/plugins/spark/features/ActuatorDS2413/ActuatorDS2413Widget.vue
@@ -28,8 +28,9 @@ export default class ActuatorDS2413Widget extends BlockWidget {
 
     <q-card-section>
       <q-item dark>
-        <q-item-section>State</q-item-section>
         <q-item-section>
+          <q-item-label caption>State</q-item-label>
+          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
           <ActuatorState
             :field="block.data.state"
             :change="callAndSaveBlock(v => block.data.state = v)"
@@ -37,14 +38,7 @@ export default class ActuatorDS2413Widget extends BlockWidget {
           />
         </q-item-section>
       </q-item>
-      <q-item v-if="isDriven">
-        <q-item-section>Driven</q-item-section>
-        <q-item-section>
-          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
-        </q-item-section>
-      </q-item>
       <q-item dark>
-        <q-item-label>Constraints</q-item-label>
         <q-item-section>
           <DigitalConstraints
             :service-id="serviceId"

--- a/src/plugins/spark/features/ActuatorDS2413/ActuatorDS2413Widget.vue
+++ b/src/plugins/spark/features/ActuatorDS2413/ActuatorDS2413Widget.vue
@@ -30,12 +30,12 @@ export default class ActuatorDS2413Widget extends BlockWidget {
       <q-item dark>
         <q-item-section>
           <q-item-label caption>State</q-item-label>
-          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
           <ActuatorState
             :field="block.data.state"
             :change="callAndSaveBlock(v => block.data.state = v)"
             :disable="isDriven"
           />
+          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
         </q-item-section>
       </q-item>
       <q-item dark>

--- a/src/plugins/spark/features/ActuatorOffset/ActuatorOffsetForm.vue
+++ b/src/plugins/spark/features/ActuatorOffset/ActuatorOffsetForm.vue
@@ -33,46 +33,42 @@ export default class ActuatorOffsetForm extends BlockForm {
           :text-disabled="`Offset is disabled: ${block.data.targetId} will not be changed.`"
         />
         <q-item dark>
-          <q-item-section>Driven Process value</q-item-section>
           <q-item-section>
+            <q-item-label caption>Driven block</q-item-label>
             <LinkPopupEdit
               :field="block.data.targetId"
               :service-id="block.serviceId"
               :change="callAndSaveBlock(v => block.data.targetId = v)"
-              label="Driven process value"
+              label="Driven block"
+              tag="span"
             />
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Reference process value</q-item-section>
           <q-item-section>
-            <LinkPopupEdit
-              :field="block.data.referenceId"
-              :service-id="block.serviceId"
-              :change="callAndSaveBlock(v => block.data.referenceId = v)"
-              label="Reference process value"
-            />
-          </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Offset from setting or current value</q-item-section>
-          <q-item-section>
-            <SelectPopupEdit
-              :field="block.data.referenceSettingOrValue"
-              :change="callAndSaveBlock(v => block.data.referenceSettingOrValue = v)"
-              :options="[{label: 'Setting', value: 0}, {label: 'Measured value', value: 1}]"
-              label="reference field"
-            />
-          </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>
-            <div class="column">
-              <span>Target Offset</span>
-              <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
+            <q-item-label caption>Offset from</q-item-label>
+            <div>
+              <LinkPopupEdit
+                :field="block.data.referenceId"
+                :service-id="block.serviceId"
+                :change="callAndSaveBlock(v => block.data.referenceId = v)"
+                label="Reference block"
+                tag="span"
+                style="display: inline-block"
+              />
+              <span class="q-px-xs">&gt;</span>
+              <SelectPopupEdit
+                :field="block.data.referenceSettingOrValue"
+                :change="callAndSaveBlock(v => block.data.referenceSettingOrValue = v)"
+                :options="[{label: 'Setting', value: 0}, {label: 'Measured value', value: 1}]"
+                label="reference field"
+                tag="span"
+                style="display: inline-block"
+              />
             </div>
           </q-item-section>
-          <q-item-section>
+        </q-item>
+        <q-item dark>
+          <q-item-section style="justify-content: flex-start">
+            <q-item-label caption>Target Offset</q-item-label>
             <InputPopupEdit
               v-if="!isDriven"
               :field="block.data.setting"
@@ -81,11 +77,10 @@ export default class ActuatorOffsetForm extends BlockForm {
               type="number"
             />
             <big v-else>{{ block.data.setting | round }}</big>
+            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Current offset</q-item-section>
-          <q-item-section>
+          <q-item-section style="justify-content: flex-start">
+            <q-item-label caption>Current offset</q-item-label>
             <big>{{ block.data.value | round }}</big>
           </q-item-section>
         </q-item>

--- a/src/plugins/spark/features/ActuatorOffset/ActuatorOffsetWidget.vue
+++ b/src/plugins/spark/features/ActuatorOffset/ActuatorOffsetWidget.vue
@@ -59,12 +59,12 @@ export default class ActuatorOffsetWidget extends BlockWidget {
       </q-item>
 
       <q-item dark>
-        <q-item-section>
+        <q-item-section style="justify-content: flex-start">
           <q-item-label caption>Target offset</q-item-label>
-          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
           <big>{{ block.data.setting | round }}</big>
+          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
         </q-item-section>
-        <q-item-section>
+        <q-item-section style="justify-content: flex-start">
           <q-item-label caption>Actual offset</q-item-label>
           <big>{{ block.data.value | round }}</big>
         </q-item-section>

--- a/src/plugins/spark/features/ActuatorOffset/ActuatorOffsetWidget.vue
+++ b/src/plugins/spark/features/ActuatorOffset/ActuatorOffsetWidget.vue
@@ -59,25 +59,17 @@ export default class ActuatorOffsetWidget extends BlockWidget {
       </q-item>
 
       <q-item dark>
-        <q-item-section>Target offset</q-item-section>
         <q-item-section>
+          <q-item-label caption>Target offset</q-item-label>
+          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
           <big>{{ block.data.setting | round }}</big>
         </q-item-section>
-      </q-item>
-      <q-item v-if="isDriven">
-        <q-item-section>Driven</q-item-section>
         <q-item-section>
-          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
-        </q-item-section>
-      </q-item>
-      <q-item dark>
-        <q-item-section>Actual offset</q-item-section>
-        <q-item-section>
+          <q-item-label caption>Actual offset</q-item-label>
           <big>{{ block.data.value | round }}</big>
         </q-item-section>
       </q-item>
       <q-item dark>
-        <q-item-label>Constraints</q-item-label>
         <AnalogConstraints
           :service-id="serviceId"
           :field="block.data.constrainedBy"

--- a/src/plugins/spark/features/ActuatorOffset/ActuatorOffsetWidget.vue
+++ b/src/plugins/spark/features/ActuatorOffset/ActuatorOffsetWidget.vue
@@ -70,12 +70,14 @@ export default class ActuatorOffsetWidget extends BlockWidget {
         </q-item-section>
       </q-item>
       <q-item dark>
-        <AnalogConstraints
-          :service-id="serviceId"
-          :field="block.data.constrainedBy"
-          :change="callAndSaveBlock(v => block.data.constrainedBy = v)"
-          readonly
-        />
+        <q-item-section>
+          <AnalogConstraints
+            :service-id="serviceId"
+            :field="block.data.constrainedBy"
+            :change="callAndSaveBlock(v => block.data.constrainedBy = v)"
+            readonly
+          />
+        </q-item-section>
       </q-item>
     </q-card-section>
   </q-card>

--- a/src/plugins/spark/features/ActuatorPin/ActuatorPinForm.vue
+++ b/src/plugins/spark/features/ActuatorPin/ActuatorPinForm.vue
@@ -44,23 +44,17 @@ export default class ActuatorPinForm extends BlockForm {
     <q-card-section>
       <q-expansion-item default-opened group="modal" icon="settings" label="Settings">
         <q-item dark>
-          <q-item-section>
-            <div class="column">
-              <span>State</span>
-              <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
-            </div>
-          </q-item-section>
-          <q-item-section>
+          <q-item-section style="justify-content: flex-start">
+            <q-item-label caption>State</q-item-label>
             <ActuatorState
               :disable="isDriven"
               :field="block.data.state"
               :change="callAndSaveBlock(v => block.data.state = v)"
             />
+            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section side>Inverted</q-item-section>
-          <q-item-section>
+          <q-item-section style="justify-content: flex-start">
+            <q-item-label caption>Inverted</q-item-label>
             <q-toggle
               :value="block.data.invert"
               @input="v => { block.data.invert = v; saveBlock(); }"

--- a/src/plugins/spark/features/ActuatorPin/ActuatorPinWidget.vue
+++ b/src/plugins/spark/features/ActuatorPin/ActuatorPinWidget.vue
@@ -63,12 +63,14 @@ export default class ActuatorPinWidget extends BlockWidget {
         </q-item-section>
       </q-item>
       <q-item dark>
-        <DigitalConstraints
-          :service-id="serviceId"
-          :field="block.data.constrainedBy"
-          :change="callAndSaveBlock(v => block.data.constrainedBy = v)"
-          readonly
-        />
+        <q-item-section>
+          <DigitalConstraints
+            :service-id="serviceId"
+            :field="block.data.constrainedBy"
+            :change="callAndSaveBlock(v => block.data.constrainedBy = v)"
+            readonly
+          />
+        </q-item-section>
       </q-item>
     </q-card-section>
   </q-card>

--- a/src/plugins/spark/features/ActuatorPin/ActuatorPinWidget.vue
+++ b/src/plugins/spark/features/ActuatorPin/ActuatorPinWidget.vue
@@ -47,17 +47,16 @@ export default class ActuatorPinWidget extends BlockWidget {
 
     <q-card-section>
       <q-item dark>
-        <q-item-section>
+        <q-item-section style="justify-content: flex-start">
           <q-item-label caption>State</q-item-label>
-          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
-
           <ActuatorState
             :field="block.data.state"
             :change="callAndSaveBlock(v => block.data.state = v)"
             :disable="isDriven"
           />
+          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
         </q-item-section>
-        <q-item-section v-if="pending !== null" dark style="justify-content: space-between">
+        <q-item-section v-if="pending !== null" dark style="justify-content: flex-start">
           <q-item-label caption>pending</q-item-label>
           <span>{{ pending }}</span>
         </q-item-section>

--- a/src/plugins/spark/features/ActuatorPin/ActuatorPinWidget.vue
+++ b/src/plugins/spark/features/ActuatorPin/ActuatorPinWidget.vue
@@ -47,35 +47,28 @@ export default class ActuatorPinWidget extends BlockWidget {
 
     <q-card-section>
       <q-item dark>
-        <q-item-section>State</q-item-section>
         <q-item-section>
+          <q-item-label caption>State</q-item-label>
+          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
+
           <ActuatorState
             :field="block.data.state"
             :change="callAndSaveBlock(v => block.data.state = v)"
             :disable="isDriven"
           />
         </q-item-section>
-      </q-item>
-      <q-item v-if="isDriven" dark>
-        <q-item-section>Driven</q-item-section>
-        <q-item-section>
-          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
+        <q-item-section v-if="pending !== null" dark style="justify-content: space-between">
+          <q-item-label caption>pending</q-item-label>
+          <span>{{ pending }}</span>
         </q-item-section>
-      </q-item>
-      <q-item v-if="pending !== null" dark>
-        <q-item-section>Pending</q-item-section>
-        <q-item-section>{{ pending }}</q-item-section>
       </q-item>
       <q-item dark>
-        <q-item-label>Constraints</q-item-label>
-        <q-item-section>
-          <DigitalConstraints
-            :service-id="serviceId"
-            :field="block.data.constrainedBy"
-            :change="callAndSaveBlock(v => block.data.constrainedBy = v)"
-            readonly
-          />
-        </q-item-section>
+        <DigitalConstraints
+          :service-id="serviceId"
+          :field="block.data.constrainedBy"
+          :change="callAndSaveBlock(v => block.data.constrainedBy = v)"
+          readonly
+        />
       </q-item>
     </q-card-section>
   </q-card>

--- a/src/plugins/spark/features/ActuatorPwm/ActuatorPwmForm.vue
+++ b/src/plugins/spark/features/ActuatorPwm/ActuatorPwmForm.vue
@@ -33,8 +33,8 @@ export default class ActuatorPwmForm extends BlockForm {
         />
 
         <q-item dark>
-          <q-item-section>Digital Actuator Target</q-item-section>
           <q-item-section>
+            <q-item-label caption>Digital Actuator Target</q-item-label>
             <LinkPopupEdit
               :field="block.data.actuatorId"
               :service-id="serviceId"
@@ -42,10 +42,8 @@ export default class ActuatorPwmForm extends BlockForm {
               label="target"
             />
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Period</q-item-section>
           <q-item-section>
+            <q-item-label caption>Period</q-item-label>
             <TimeUnitPopupEdit
               :field="block.data.period"
               :change="callAndSaveBlock(v => block.data.period = v)"
@@ -55,13 +53,8 @@ export default class ActuatorPwmForm extends BlockForm {
           </q-item-section>
         </q-item>
         <q-item dark>
-          <q-item-section>
-            <div class="column">
-              <span>Duty setting</span>
-              <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
-            </div>
-          </q-item-section>
-          <q-item-section>
+          <q-item-section style="justify-content: flex-start">
+            <q-item-label caption>Duty setting</q-item-label>
             <InputPopupEdit
               v-if="!isDriven"
               :field="block.data.setting"
@@ -70,11 +63,10 @@ export default class ActuatorPwmForm extends BlockForm {
               type="number"
             />
             <big v-else>{{ block.data.setting | round }}</big>
+            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Duty Achieved</q-item-section>
-          <q-item-section>
+          <q-item-section style="justify-content: flex-start">
+            <q-item-label caption>Duty Achieved</q-item-label>
             <big>{{ block.data.value | round }}</big>
           </q-item-section>
         </q-item>

--- a/src/plugins/spark/features/ActuatorPwm/ActuatorPwmWidget.vue
+++ b/src/plugins/spark/features/ActuatorPwm/ActuatorPwmWidget.vue
@@ -68,11 +68,16 @@ export default class ActuatorPwmWidget extends BlockWidget {
               v-if="!isDriven"
               :field="block.data.setting"
               :change="callAndSaveBlock(v => block.data.setting = v)"
+              style="display: inline-block"
               type="number"
-              label="Setting"
+              label="Duty Setting"
             />
             <big v-else>{{ block.data.setting | round }}</big>
-            <small class="q-ml-xs">%</small>
+            <small
+              v-if="block.data.setting !== null"
+              style="display: inline-block"
+              class="q-ml-xs"
+            >%</small>
           </div>
         </q-item-section>
         <q-item-section style="justify-content: space-between">

--- a/src/plugins/spark/features/ActuatorPwm/ActuatorPwmWidget.vue
+++ b/src/plugins/spark/features/ActuatorPwm/ActuatorPwmWidget.vue
@@ -80,7 +80,7 @@ export default class ActuatorPwmWidget extends BlockWidget {
             >%</small>
           </div>
         </q-item-section>
-        <q-item-section style="justify-content: space-between">
+        <q-item-section style="justify-content: flex-start">
           <q-item-label caption>Duty achieved</q-item-label>
           <div>
             <big>{{ block.data.value | round }}</big>

--- a/src/plugins/spark/features/ActuatorPwm/ActuatorPwmWidget.vue
+++ b/src/plugins/spark/features/ActuatorPwm/ActuatorPwmWidget.vue
@@ -61,36 +61,39 @@ export default class ActuatorPwmWidget extends BlockWidget {
 
       <q-item dark>
         <q-item-section>
-          <div class="column">
-            <span>Duty setting</span>
-            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
+          <q-item-label caption>Duty setting</q-item-label>
+          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
+          <div>
+            <InputPopupEdit
+              v-if="!isDriven"
+              :field="block.data.setting"
+              :change="callAndSaveBlock(v => block.data.setting = v)"
+              type="number"
+              label="Setting"
+            />
+            <big v-else>{{ block.data.setting | round }}</big>
+            <small class="q-ml-xs">%</small>
           </div>
         </q-item-section>
-        <q-item-section>
-          <InputPopupEdit
-            v-if="!isDriven"
-            :field="block.data.setting"
-            :change="callAndSaveBlock(v => block.data.setting = v)"
-            label="Setting"
-            type="number"
-          />
-          <big v-else>{{ block.data.setting | round }}</big>
+        <q-item-section style="justify-content: space-between">
+          <q-item-label caption>Duty achieved</q-item-label>
+          <div>
+            <big>{{ block.data.value | round }}</big>
+            <small class="q-ml-xs">%</small>
+          </div>
         </q-item-section>
       </q-item>
-      <q-item dark>
-        <q-item-section>Duty achieved</q-item-section>
-        <q-item-section>
-          <big>{{ block.data.value | round }}</big>
-        </q-item-section>
-      </q-item>
+
       <q-item v-if="pending !== null" dark>
-        <q-item-section>Unconstrained setting</q-item-section>
         <q-item-section>
-          <big>{{ pending | round }}</big>
+          <q-item-label caption>Unconstrained setting</q-item-label>
+          <div>
+            <big>{{ pending | round }}</big>
+            <small class="q-ml-xs">%</small>
+          </div>
         </q-item-section>
       </q-item>
       <q-item dark>
-        <q-item-label>Constraints</q-item-label>
         <q-item-section>
           <AnalogConstraints
             :service-id="serviceId"

--- a/src/plugins/spark/features/Balancer/BalancerForm.vue
+++ b/src/plugins/spark/features/Balancer/BalancerForm.vue
@@ -23,9 +23,19 @@ export default class BalancerForm extends BlockForm {
 <template>
   <q-card dark class="widget-modal">
     <BlockFormToolbar v-if="!$props.embedded" v-bind="$props" :block="block"/>
-
-    <q-expansion-item default-opened group="modal" icon="mdi-cube" label="Block Settings">
-      <BlockSettings v-bind="$props" :presets-data="presets()"/>
-    </q-expansion-item>
+    <q-card-section>
+      <q-item dark>
+        <q-item-section>
+          <q-item-label caption>Note</q-item-label>
+          <span>
+            To power balance multiple analog actuators,
+            set a balanced constraint on them with this block as target.
+          </span>
+        </q-item-section>
+      </q-item>
+      <q-expansion-item default-opened group="modal" icon="mdi-cube" label="Block Settings">
+        <BlockSettings v-bind="$props" :presets-data="presets()"/>
+      </q-expansion-item>
+    </q-card-section>
   </q-card>
 </template>

--- a/src/plugins/spark/features/Balancer/BalancerWidget.vue
+++ b/src/plugins/spark/features/Balancer/BalancerWidget.vue
@@ -27,7 +27,7 @@ export default class BalancerWidget extends BlockWidget {
           [`clients/${idx}/granted`]: `${this.clientName(client.id)} granted`,
         }),
         {},
-    );
+      );
   }
 }
 </script>
@@ -41,18 +41,20 @@ export default class BalancerWidget extends BlockWidget {
     <BlockWidgetToolbar :field="me" graph/>
 
     <q-card-section>
-      <q-item dark>
+      <q-item dark dense style="opacity: 0.5">
         <q-item-section>Client</q-item-section>
         <q-item-section>Granted</q-item-section>
         <q-item-section>Requested</q-item-section>
       </q-item>
-      <q-item v-for="client in block.data.clients" :key="client.id.id" dark>
-        <q-item-section>
-          <i>{{ clientName(client.id) }}</i>
-        </q-item-section>
-        <q-item-section>{{ client.granted | round }}</q-item-section>
-        <q-item-section>{{ client.requested | round }}</q-item-section>
-      </q-item>
+      <q-list dense>
+        <q-item v-for="client in block.data.clients" :key="client.id.id" dark>
+          <q-item-section>
+            <i>{{ clientName(client.id) }}</i>
+          </q-item-section>
+          <q-item-section>{{ client.granted | round }}</q-item-section>
+          <q-item-section>{{ client.requested | round }}</q-item-section>
+        </q-item>
+      </q-list>
     </q-card-section>
   </q-card>
 </template>

--- a/src/plugins/spark/features/DS2413/DS2413Form.vue
+++ b/src/plugins/spark/features/DS2413/DS2413Form.vue
@@ -29,9 +29,17 @@ export default class DS2413Form extends BlockForm {
 <template>
   <q-card dark class="widget-modal">
     <BlockFormToolbar v-if="!$props.embedded" v-bind="$props" :block="block"/>
+    <q-card-section>
+      <q-item dark>
+        <q-item-section>
+          <q-item-label caption>Note</q-item-label>
+          <span>This block is the DS2413 chip with 2 channels. Please create a DS2413 Actuator block for each of the channels you want to use.</span>
+        </q-item-section>
+      </q-item>
 
-    <q-expansion-item default-opened group="modal" icon="mdi-cube" label="Block Settings">
-      <BlockSettings v-bind="$props" :presets-data="presets()"/>
-    </q-expansion-item>
+      <q-expansion-item default-opened group="modal" icon="mdi-cube" label="Block Settings">
+        <BlockSettings v-bind="$props" :presets-data="presets()"/>
+      </q-expansion-item>
+    </q-card-section>
   </q-card>
 </template>

--- a/src/plugins/spark/features/DS2413/DS2413Widget.vue
+++ b/src/plugins/spark/features/DS2413/DS2413Widget.vue
@@ -35,22 +35,19 @@ export default class DS2413Widget extends BlockWidget {
 
     <q-card-section>
       <q-item dark>
-        <q-item-section>Address</q-item-section>
-        <q-item-section>{{ address }}</q-item-section>
-      </q-item>
-      <q-item dark>
         <q-item-section>
-          <div class="column">
-            <span>State</span>
-            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
+          <q-item-label caption>Latches</q-item-label>
+          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
+          <div>
+            <q-toggle :value="pinState.latchA" class="col-6" readonly label="Latch A"/>
+            <q-toggle :value="pinState.latchB" class="col-6" readonly label="Latch B"/>
           </div>
         </q-item-section>
-        <q-item-section>
-          <div class="col">
-            <q-toggle :value="pinState.latchA" readonly label="Latch A"/>
-            <q-toggle :value="pinState.senseA" readonly label="Sense A"/>
-            <q-toggle :value="pinState.latchB" readonly label="Latch B"/>
-            <q-toggle :value="pinState.senseB" readonly label="Sense B"/>
+        <q-item-section style="justify-content: space-between">
+          <q-item-label caption>Sensing</q-item-label>
+          <div>
+            <q-toggle :value="pinState.senseA" class="col-6" readonly label="Sense A"/>
+            <q-toggle :value="pinState.senseB" class="col-6" readonly label="Sense B"/>
           </div>
         </q-item-section>
       </q-item>

--- a/src/plugins/spark/features/DS2413/DS2413Widget.vue
+++ b/src/plugins/spark/features/DS2413/DS2413Widget.vue
@@ -35,15 +35,15 @@ export default class DS2413Widget extends BlockWidget {
 
     <q-card-section>
       <q-item dark>
-        <q-item-section>
+        <q-item-section style="justify-content: flex-start">
           <q-item-label caption>Latches</q-item-label>
-          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
           <div>
             <q-toggle :value="pinState.latchA" class="col-6" readonly label="Latch A"/>
             <q-toggle :value="pinState.latchB" class="col-6" readonly label="Latch B"/>
           </div>
+          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
         </q-item-section>
-        <q-item-section style="justify-content: space-between">
+        <q-item-section style="justify-content: flex-start">
           <q-item-label caption>Sensing</q-item-label>
           <div>
             <q-toggle :value="pinState.senseA" class="col-6" readonly label="Sense A"/>

--- a/src/plugins/spark/features/DisplaySettings/DisplaySettingsForm.vue
+++ b/src/plugins/spark/features/DisplaySettings/DisplaySettingsForm.vue
@@ -161,6 +161,31 @@ export default class DisplaySettingsForm extends BlockForm {
         </q-item-section>
       </q-item>
     </q-expansion-item>
+    <q-expansion-item group="modal" icon="mdi-format-text" label="Shared Display Settings">
+      <q-item dark>
+        <q-item-section side>Footer text</q-item-section>
+        <q-item-section>
+          <InputPopupEdit
+            :field="block.data.name"
+            :change="callAndSaveBlock(v => block.data.name = v)"
+            label="Footer text"
+            tag="span"
+          />
+        </q-item-section>
+      </q-item>
+      <q-item dark>
+        <q-item-section side>Temperature Unit</q-item-section>
+        <q-item-section>
+          <SelectPopupEdit
+            :field="block.data.tempUnit"
+            :options="[{ label: 'Celsius', value: 0 }, { label: 'Fahrenheit', value: 1 }]"
+            :change="callAndSaveBlock(v => block.data.tempUnit = v)"
+            label="Temperature Unit"
+            tag="span"
+          />
+        </q-item-section>
+      </q-item>
+    </q-expansion-item>
 
     <q-expansion-item group="modal" icon="mdi-cube" label="Block Settings">
       <BlockSettings v-bind="$props" :presets-data="presets()"/>

--- a/src/plugins/spark/features/DisplaySettings/DisplaySettingsWidget.vue
+++ b/src/plugins/spark/features/DisplaySettings/DisplaySettingsWidget.vue
@@ -26,23 +26,22 @@ export default class DisplaySettingsWidget extends BlockWidget {
 <template>
   <q-card dark class="text-white scroll">
     <q-dialog v-model="modalOpen" no-backdrop-dismiss>
-      <DisplaySettingsForm
-        v-if="modalOpen"
-        v-bind="formProps"
-      />
+      <DisplaySettingsForm v-if="modalOpen" v-bind="formProps"/>
     </q-dialog>
 
     <BlockWidgetToolbar :field="me"/>
 
     <q-card-section>
       <q-list dark dense>
-        <q-item v-for="(slot, idx) in displaySlots" :key="idx">
-          <q-item-section side>Slot {{ idx + 1 }}</q-item-section>
-          <q-item-section>
-            <big v-if="slot" :style="slotStyle(slot)">{{ slot.name }}</big>
-            <big v-else>Not set</big>
-          </q-item-section>
-        </q-item>
+        <div class="row">
+          <q-item v-for="(slot, idx) in displaySlots" :key="idx" class="col-4">
+            <q-item-section>
+              <q-item-label caption>Slot {{ idx + 1 }}</q-item-label>
+              <span v-if="slot" :style="slotStyle(slot)" class="text-bold">{{ slot.name }}</span>
+              <span v-else class="darkened">Not set</span>
+            </q-item-section>
+          </q-item>
+        </div>
 
         <q-item dark>
           <q-item-section side>Footer text</q-item-section>
@@ -51,18 +50,6 @@ export default class DisplaySettingsWidget extends BlockWidget {
               :field="block.data.name"
               :change="callAndSaveBlock(v => block.data.name = v)"
               label="footer text"
-              tag="span"
-            />
-          </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section side>Temperature Unit</q-item-section>
-          <q-item-section>
-            <SelectPopupEdit
-              :field="block.data.tempUnit"
-              :options="[{ label: 'Celsius', value: 0 }, { label: 'Fahrenheit', value: 1 }]"
-              :change="callAndSaveBlock(v => block.data.tempUnit = v)"
-              label="Temperature Unit"
               tag="span"
             />
           </q-item-section>

--- a/src/plugins/spark/features/Mutex/MutexForm.vue
+++ b/src/plugins/spark/features/Mutex/MutexForm.vue
@@ -24,13 +24,13 @@ export default class MutexForm extends BlockForm {
     <q-card-section>
       <q-expansion-item default-opened group="modal" icon="settings" label="Settings">
         <q-item dark>
-          <q-item-section>Idle time before allowing a different actuator</q-item-section>
           <q-item-section>
+            <q-item-label caption>Idle time before allowing a different actuator</q-item-label>
             <TimeUnitPopupEdit
               :field="block.data.differentActuatorWait"
               :change="callAndSaveBlock(v => block.data.differentActuatorWait = v)"
               type="number"
-              label="minimum idle time"
+              label="Minimum idle time"
             />
           </q-item-section>
         </q-item>

--- a/src/plugins/spark/features/Mutex/MutexWidget.vue
+++ b/src/plugins/spark/features/Mutex/MutexWidget.vue
@@ -26,28 +26,24 @@ export default class MutexWidget extends BlockWidget {
 
     <q-card-section>
       <q-item dark>
-        <q-item-section>Held by</q-item-section>
-        <q-item-section>{{ mutexClients.active }}</q-item-section>
-      </q-item>
-      <q-item dark>
-        <q-item-section>Waiting</q-item-section>
-        <q-item-section>
-          <div class="column">
-            <span v-for="client in mutexClients.waiting" :key="client">{{ client }}</span>
-          </div>
+        <q-item-section style="justify-content: flex-start">
+          <q-item-label caption>Held by</q-item-label>
+          <div>{{ mutexClients.active }}</div>
+        </q-item-section>
+        <q-item-section style="justify-content: flex-start">
+          <q-item-label caption>Waiting</q-item-label>
+          <div v-for="client in mutexClients.waiting" :key="client">{{ client }}</div>
+        </q-item-section>
+        <q-item-section style="justify-content: flex-start">
+          <q-item-label caption>Idle</q-item-label>
+          <div v-for="client in mutexClients.idle" :key="client">{{ client }}</div>
         </q-item-section>
       </q-item>
       <q-item dark>
-        <q-item-section>Idle</q-item-section>
         <q-item-section>
-          <div class="column">
-            <span v-for="client in mutexClients.idle" :key="client">{{ client }}</span>
-          </div>
+          <q-item-label caption>Wait time remaining</q-item-label>
+          <div>{{ block.data.waitRemaining | unitDuration }}</div>
         </q-item-section>
-      </q-item>
-      <q-item dark>
-        <q-item-section>Wait time remaining</q-item-section>
-        <q-item-section>{{ block.data.waitRemaining | unitDuration }}</q-item-section>
       </q-item>
     </q-card-section>
   </q-card>

--- a/src/plugins/spark/features/Pid/PidForm.vue
+++ b/src/plugins/spark/features/Pid/PidForm.vue
@@ -39,8 +39,8 @@ export default class PidForm extends BlockForm {
         <q-separator dark inset/>
 
         <q-item dark>
-          <q-item-section>Input Block</q-item-section>
           <q-item-section>
+            <q-item-label caption>Input Block</q-item-label>
             <LinkPopupEdit
               :field="block.data.inputId"
               :service-id="block.serviceId"
@@ -56,20 +56,21 @@ export default class PidForm extends BlockForm {
               <p>The input target minus the input value is called the error</p>
             </LinkPopupEdit>
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Target value is</q-item-section>
-          <q-item-section class="text-bold">{{ block.data.inputSetting | unit }}</q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Current value is</q-item-section>
-          <q-item-section class="text-bold">{{ block.data.inputValue | unit }}</q-item-section>
+
+          <q-item-section>
+            <q-item-label caption>Target value is</q-item-label>
+            <q-item-section class="text-bold">{{ block.data.inputSetting | unit }}</q-item-section>
+          </q-item-section>
+          <q-item-section>
+            <q-item-label caption>Current value is</q-item-label>
+            <div class="text-bold">{{ block.data.inputValue | unit }}</div>
+          </q-item-section>
         </q-item>
         <q-separator dark inset/>
 
         <q-item dark>
-          <q-item-section>Output Block</q-item-section>
           <q-item-section>
+            <q-item-label caption>Output Block</q-item-label>
             <LinkPopupEdit
               :field="block.data.outputId"
               :service-id="block.serviceId"
@@ -88,20 +89,22 @@ export default class PidForm extends BlockForm {
               </p>
             </LinkPopupEdit>
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Target value is</q-item-section>
-          <q-item-section class="text-bold">{{ block.data.outputSetting | round }}</q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Current value is</q-item-section>
-          <q-item-section class="text-bold">{{ block.data.outputValue | unit }}</q-item-section>
+
+          <q-item-section>
+            <q-item-label caption>Target value is</q-item-label>
+            <div class="text-bold">{{ block.data.outputSetting | round }}</div>
+          </q-item-section>
+
+          <q-item-section>
+            <q-item-label caption>Current value is</q-item-label>
+            <div class="text-bold">{{ block.data.outputValue | round }}</div>
+          </q-item-section>
         </q-item>
         <q-separator dark inset/>
 
         <q-item dark>
-          <q-item-section>Filter period</q-item-section>
           <q-item-section>
+            <q-item-label caption>Filter period</q-item-label>
             <SelectPopupEdit
               :field="block.data.filter"
               :change="callAndSaveBlock(v => block.data.filter = v)"
@@ -116,10 +119,9 @@ export default class PidForm extends BlockForm {
               <p>The filter should block changes lasting shorter than:</p>
             </SelectPopupEdit>
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Fast step threshold</q-item-section>
+
           <q-item-section>
+            <q-item-label caption>Fast step threshold</q-item-label>
             <UnitPopupEdit
               :field="block.data.filterThreshold"
               :change="callAndSaveBlock(v => block.data.filterThreshold = v)"
@@ -133,6 +135,7 @@ export default class PidForm extends BlockForm {
               <p>If a step exceeds this threshold, respond faster:</p>
             </UnitPopupEdit>
           </q-item-section>
+          <q-item-section/>
         </q-item>
         <q-separator dark inset/>
 
@@ -251,7 +254,10 @@ export default class PidForm extends BlockForm {
         </q-item>
         <q-item dark>
           <q-item-section v-for="i in 6" :key="i"/>
-          <q-item-section>{{ block.data.p + block.data.i + block.data.d | round }}</q-item-section>
+          <q-item-section>
+            <q-item-label caption>Output</q-item-label>
+            {{ block.data.p + block.data.i + block.data.d | round }}
+          </q-item-section>
         </q-item>
       </q-expansion-item>
 

--- a/src/plugins/spark/features/Pid/PidWidget.vue
+++ b/src/plugins/spark/features/Pid/PidWidget.vue
@@ -53,107 +53,121 @@ export default class PidWidget extends BlockWidget {
     <BlockWidgetToolbar :field="me" graph/>
 
     <q-card-section>
-      <q-item v-if="!block.data.enabled" dark>
-        <q-item-section avatar>
-          <q-icon name="warning"/>
+      <template v-if="!block.data.enabled">
+        <q-item dark>
+          <q-item-section avatar>
+            <q-icon name="warning"/>
+          </q-item-section>
+          <q-item-section>
+            <span>
+              PID is disabled:
+              <i>{{ block.data.outputId }}</i> will not be set.
+            </span>
+          </q-item-section>
+          <q-item-section side>
+            <q-btn text-color="white" flat label="Enable" @click="enable"/>
+          </q-item-section>
+        </q-item>
+        <q-separator dark inset class="q-mb-md"/>
+      </template>
+
+      <template v-else-if="!block.data.active">
+        <q-item dark>
+          <q-item-section avatar>
+            <q-icon name="warning"/>
+          </q-item-section>
+          <q-item-section>
+            <span>
+              PID is inactive:
+              <i>{{ block.data.outputId }}</i> will not be set.
+            </span>
+          </q-item-section>
+        </q-item>
+        <q-separator dark inset class="q-mb-md"/>
+      </template>
+
+      <q-item dark>
+        <div class="col-3 text-weight-light text-subtitle2 q-pt-xs">Input</div>
+        <q-item-section>
+          <q-item-label caption>Measured</q-item-label>
+          <div>
+            <big>{{ block.data.inputValue.val | round }}</big>
+            <span class="q-ml-xs">{{ block.data.inputValue.notation }}</span>
+          </div>
         </q-item-section>
         <q-item-section>
-          <span>
-            PID is disabled:
-            <i>{{ block.data.outputId }}</i> will not be set.
-          </span>
-        </q-item-section>
-        <q-item-section side>
-          <q-btn text-color="white" flat label="Enable" @click="enable"/>
+          <q-item-label caption>Target</q-item-label>
+          <div>
+            <big>{{ block.data.inputSetting.val | round }}</big>
+            <span class="q-ml-xs">{{ block.data.inputSetting.notation }}</span>
+          </div>
         </q-item-section>
       </q-item>
 
-      <q-item v-if="block.data.enabled && !block.data.active" dark>
-        <q-item-section avatar>
-          <q-icon name="warning"/>
+      <q-separator dark inset/>
+
+      <q-item dark>
+        <div class="col-3 text-weight-light text-subtitle2 q-pt-xs">Output</div>
+        <q-item-section>
+          <q-item-label caption>Measured</q-item-label>
+          <big>{{ block.data.outputSetting | round }}</big>
         </q-item-section>
         <q-item-section>
-          <span>
-            PID is inactive:
-            <i>{{ block.data.outputId }}</i> will not be set.
-          </span>
+          <q-item-label caption>Target</q-item-label>
+          <big>{{ block.data.outputValue | round }}</big>
         </q-item-section>
       </q-item>
 
-      <q-list dense dark>
-        <q-item dark>
-          <q-item-section>Target input</q-item-section>
-          <q-item-section>
-            <big>{{ block.data.inputSetting | unit }}</big>
-          </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Actual input</q-item-section>
-          <q-item-section>
-            <big>{{ block.data.inputValue | unit }}</big>
-          </q-item-section>
-        </q-item>
-        <q-separator dark inset/>
-      </q-list>
+      <q-separator dark inset/>
 
-      <q-list dense dark>
-        <q-item dark>
-          <q-item-section>Target output</q-item-section>
-          <q-item-section>
-            <big>{{ block.data.outputSetting | round }}</big>
-          </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Actual output</q-item-section>
-          <q-item-section>
-            <big>{{ block.data.outputSetting | round }}</big>
-          </q-item-section>
-        </q-item>
-        <q-separator dark inset/>
-      </q-list>
+      <q-item dark>
+        <div class="col-3 text-weight-light text-subtitle2 q-pt-xs">Error</div>
+        <q-item-section>
+          <q-item-label caption>Proportional</q-item-label>
+          <div>
+            <span>{{ block.data.error.val | round }}</span>
+            <small class="q-ml-xs">{{ block.data.error.notation }}</small>
+          </div>
+        </q-item-section>
+        <q-item-section>
+          <q-item-label caption>Integral</q-item-label>
+          <div>
+            <span>{{ block.data.integral.val | round }}</span>
+            <small class="q-ml-xs">{{ block.data.integral.notation }}</small>
+          </div>
+        </q-item-section>
+        <q-item-section>
+          <q-item-label caption>Derivative</q-item-label>
+          <div>
+            <span>{{ block.data.derivative.val | round }}</span>
+            <small class="q-ml-xs">{{ block.data.derivative.notation }}</small>
+          </div>
+        </q-item-section>
+      </q-item>
 
-      <q-list dense dark>
-        <q-item dark>
-          <q-item-section>Error</q-item-section>
-          <q-item-section>
-            <big>{{ block.data.error | unit }}</big>
-          </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Integral</q-item-section>
-          <q-item-section>
-            <big>{{ block.data.integral | unit }}</big>
-          </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Derivative</q-item-section>
-          <q-item-section>
-            <big>{{ block.data.derivative | unit }}</big>
-          </q-item-section>
-        </q-item>
-        <q-separator dark inset/>
-      </q-list>
+      <q-separator dark inset/>
 
-      <q-list dense dark>
-        <q-item dark class="q-my-none">
-          <q-item-section>P</q-item-section>
-          <q-item-section>
-            <big>{{ block.data.p | round }}</big>
-          </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>I</q-item-section>
-          <q-item-section>
-            <big>{{ block.data.i | round }}</big>
-          </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>D</q-item-section>
-          <q-item-section>
-            <big>{{ block.data.d | round }}</big>
-          </q-item-section>
-        </q-item>
-      </q-list>
+      <q-item dark>
+        <div class="col-3 text-weight-light text-subtitle2 q-pt-xs">Result</div>
+        <q-item-section>
+          <q-item-label caption>P</q-item-label>
+          <span>{{ block.data.p | round }}</span>
+        </q-item-section>
+        <q-item-section>
+          <q-item-label caption>I</q-item-label>
+          <span>{{ block.data.i | round }}</span>
+        </q-item-section>
+        <q-item-section>
+          <q-item-label caption>D</q-item-label>
+          <span>{{ block.data.d | round }}</span>
+        </q-item-section>
+      </q-item>
     </q-card-section>
   </q-card>
 </template>
+
+<style lang="stylus" scoped>
+.q-card__section .q-separator {
+  opacity: 0.2;
+}
+</style>

--- a/src/plugins/spark/features/Pid/PidWidget.vue
+++ b/src/plugins/spark/features/Pid/PidWidget.vue
@@ -90,17 +90,11 @@ export default class PidWidget extends BlockWidget {
         <div class="col-3 text-weight-light text-subtitle2 q-pt-xs">Input</div>
         <q-item-section>
           <q-item-label caption>Measured</q-item-label>
-          <div>
-            <big>{{ block.data.inputValue.val | round }}</big>
-            <span class="q-ml-xs">{{ block.data.inputValue.notation }}</span>
-          </div>
+          <UnitField :field="block.data.inputValue"/>
         </q-item-section>
         <q-item-section>
           <q-item-label caption>Target</q-item-label>
-          <div>
-            <big>{{ block.data.inputSetting.val | round }}</big>
-            <span class="q-ml-xs">{{ block.data.inputSetting.notation }}</span>
-          </div>
+          <UnitField :field="block.data.inputSetting"/>
         </q-item-section>
       </q-item>
 
@@ -124,24 +118,15 @@ export default class PidWidget extends BlockWidget {
         <div class="col-3 text-weight-light text-subtitle2 q-pt-xs">Error</div>
         <q-item-section>
           <q-item-label caption>Proportional</q-item-label>
-          <div>
-            <span>{{ block.data.error.val | round }}</span>
-            <small class="q-ml-xs">{{ block.data.error.notation }}</small>
-          </div>
+          <UnitField :field="block.data.error" tag="span" unit-tag="small"/>
         </q-item-section>
         <q-item-section>
           <q-item-label caption>Integral</q-item-label>
-          <div>
-            <span>{{ block.data.integral.val | round }}</span>
-            <small class="q-ml-xs">{{ block.data.integral.notation }}</small>
-          </div>
+          <UnitField :field="block.data.integral" tag="span" unit-tag="small"/>
         </q-item-section>
         <q-item-section>
           <q-item-label caption>Derivative</q-item-label>
-          <div>
-            <span>{{ block.data.derivative.val | round }}</span>
-            <small class="q-ml-xs">{{ block.data.derivative.notation }}</small>
-          </div>
+          <UnitField :field="block.data.derivative" tag="span" unit-tag="small"/>
         </q-item-section>
       </q-item>
 

--- a/src/plugins/spark/features/SessionView/SessionViewForm.vue
+++ b/src/plugins/spark/features/SessionView/SessionViewForm.vue
@@ -177,8 +177,8 @@ export default class SessionViewForm extends FormBase {
           </q-item>
           <q-separator dark/>
           <q-item dark>
-            <q-item-section>Session name</q-item-section>
             <q-item-section>
+              <q-item-label caption>Session name</q-item-label>
               <InputPopupEdit
                 :field="session.name"
                 :change="v => { session.name = v; updateSession(session); }"
@@ -186,10 +186,16 @@ export default class SessionViewForm extends FormBase {
                 tag="span"
               />
             </q-item-section>
+            <q-item-section>
+              <q-item-label caption>Duration</q-item-label>
+              <span v-if="session.start && session.end">{{ sessionDuration(session) }}</span>
+              <span v-else-if="session.start">In progress...</span>
+              <span v-else>Not yet started</span>
+            </q-item-section>
           </q-item>
           <q-item dark>
-            <q-item-section>Start</q-item-section>
             <q-item-section>
+              <q-item-label caption>Start</q-item-label>
               <DatetimePopupEdit
                 :field="session.start"
                 :change="v => startSession(session, v)"
@@ -199,10 +205,9 @@ export default class SessionViewForm extends FormBase {
                 clear-label="<click to start>"
               />
             </q-item-section>
-          </q-item>
-          <q-item dark>
-            <q-item-section>End</q-item-section>
+
             <q-item-section>
+              <q-item-label caption>End</q-item-label>
               <DatetimePopupEdit
                 :field="session.end"
                 :change="v => endSession(session, v)"
@@ -212,12 +217,6 @@ export default class SessionViewForm extends FormBase {
                 clear-label="<click to end>"
               />
             </q-item-section>
-          </q-item>
-          <q-item dark>
-            <q-item-section>Duration</q-item-section>
-            <q-item-section v-if="session.start && session.end">{{ sessionDuration(session) }}</q-item-section>
-            <q-item-section v-else-if="session.start">In progress...</q-item-section>
-            <q-item-section v-else>Not yet started</q-item-section>
           </q-item>
 
           <q-expansion-item group="sub-modal" icon="mdi-file-tree" label="Fields">

--- a/src/plugins/spark/features/SetpointProfile/SetpointProfileForm.vue
+++ b/src/plugins/spark/features/SetpointProfile/SetpointProfileForm.vue
@@ -148,17 +148,8 @@ export default class SetpointProfileForm extends BlockForm {
     <q-card-section>
       <q-expansion-item group="modal" icon="settings" label="Settings">
         <q-item dark>
-          <q-item-section>Enabled</q-item-section>
           <q-item-section>
-            <q-toggle
-              :value="block.data.enabled"
-              @input="v => { block.data.enabled = v; saveBlock(); }"
-            />
-          </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Current setting</q-item-section>
-          <q-item-section>
+            <q-item-label caption>Current setting</q-item-label>
             <big>{{ block.data.setting | unit }}</big>
           </q-item-section>
         </q-item>

--- a/src/plugins/spark/features/SetpointSensorPair/SetpointSensorPairForm.vue
+++ b/src/plugins/spark/features/SetpointSensorPair/SetpointSensorPairForm.vue
@@ -29,12 +29,7 @@ export default class SetpointSensorPairForm extends BlockForm {
       <q-expansion-item default-opened group="modal" icon="settings" label="Settings">
         <q-item dark>
           <q-item-section>
-            <div class="column">
-              <span>Setpoint</span>
-              <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
-            </div>
-          </q-item-section>
-          <q-item-section>
+            <q-item-label caption>Setpoint</q-item-label>
             <LinkPopupEdit
               :field="block.data.setpointId"
               :service-id="serviceId"
@@ -42,10 +37,8 @@ export default class SetpointSensorPairForm extends BlockForm {
               label="Setpoint"
             />
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Sensor</q-item-section>
           <q-item-section>
+            <q-item-label caption>Sensor</q-item-label>
             <LinkPopupEdit
               :field="block.data.sensorId"
               :service-id="serviceId"

--- a/src/plugins/spark/features/SetpointSensorPair/SetpointSensorPairWidget.vue
+++ b/src/plugins/spark/features/SetpointSensorPair/SetpointSensorPairWidget.vue
@@ -36,17 +36,11 @@ export default class SetpointSensorPairWidget extends BlockWidget {
         <q-item-section>
           <q-item-label caption>Setpoint</q-item-label>
           <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
-          <div>
-            <big>{{ block.data.setpointValue.val | round }}</big>
-            <span class="q-ml-xs">{{ block.data.setpointValue.notation }}</span>
-          </div>
+          <UnitField :field="block.data.setpointValue"/>
         </q-item-section>
-        <q-item-section>
+        <q-item-section style="justify-content: space-between">
           <q-item-label caption>Sensor</q-item-label>
-          <div>
-            <big>{{ block.data.sensorValue.val | round }}</big>
-            <span class="q-ml-xs">{{ block.data.sensorValue.notation }}</span>
-          </div>
+          <UnitField :field="block.data.sensorValue"/>
         </q-item-section>
       </q-item>
     </q-card-section>

--- a/src/plugins/spark/features/SetpointSensorPair/SetpointSensorPairWidget.vue
+++ b/src/plugins/spark/features/SetpointSensorPair/SetpointSensorPairWidget.vue
@@ -34,19 +34,19 @@ export default class SetpointSensorPairWidget extends BlockWidget {
     <q-card-section>
       <q-item dark>
         <q-item-section>
-          <div class="column">
-            <span>Setpoint value</span>
-            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
+          <q-item-label caption>Setpoint</q-item-label>
+          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
+          <div>
+            <big>{{ block.data.setpointValue.val | round }}</big>
+            <span class="q-ml-xs">{{ block.data.setpointValue.notation }}</span>
           </div>
         </q-item-section>
         <q-item-section>
-          <big>{{ block.data.setpointValue | unit }}</big>
-        </q-item-section>
-      </q-item>
-      <q-item dark>
-        <q-item-section>Sensor value</q-item-section>
-        <q-item-section>
-          <big>{{ block.data.sensorValue | unit }}</big>
+          <q-item-label caption>Sensor</q-item-label>
+          <div>
+            <big>{{ block.data.sensorValue.val | round }}</big>
+            <span class="q-ml-xs">{{ block.data.sensorValue.notation }}</span>
+          </div>
         </q-item-section>
       </q-item>
     </q-card-section>

--- a/src/plugins/spark/features/SetpointSensorPair/SetpointSensorPairWidget.vue
+++ b/src/plugins/spark/features/SetpointSensorPair/SetpointSensorPairWidget.vue
@@ -33,12 +33,12 @@ export default class SetpointSensorPairWidget extends BlockWidget {
 
     <q-card-section>
       <q-item dark>
-        <q-item-section>
+        <q-item-section style="justify-content: flex-start">
           <q-item-label caption>Setpoint</q-item-label>
-          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
           <UnitField :field="block.data.setpointValue"/>
+          <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
         </q-item-section>
-        <q-item-section style="justify-content: space-between">
+        <q-item-section style="justify-content: flex-start">
           <q-item-label caption>Sensor</q-item-label>
           <UnitField :field="block.data.sensorValue"/>
         </q-item-section>

--- a/src/plugins/spark/features/SetpointSimple/SetpointSimpleForm.vue
+++ b/src/plugins/spark/features/SetpointSimple/SetpointSimpleForm.vue
@@ -26,8 +26,9 @@ export default class SetpointSimpleForm extends BlockForm {
     <q-card-section>
       <q-expansion-item default-opened group="modal" icon="settings" label="Settings">
         <q-item dark>
-          <q-item-section side>Target</q-item-section>
           <q-item-section>
+            <q-item-label caption>Target</q-item-label>
+            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
             <UnitPopupEdit
               v-if="!isDriven"
               :class="{ darkened: block.data.setting.value === null }"
@@ -40,13 +41,9 @@ export default class SetpointSimpleForm extends BlockForm {
               :class="{ darkened: block.data.setting.value === null }"
             >{{ block.data.setpoint | unit }}</big>
           </q-item-section>
-          <q-item-section>
-            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
-          </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section side>Enabled</q-item-section>
-          <q-item-section>
+
+          <q-item-section style="justify-content: space-between">
+            <q-item-label caption>Enabled</q-item-label>
             <q-toggle
               :value="block.data.enabled"
               @input="v => { block.data.enabled = v; saveBlock(); }"

--- a/src/plugins/spark/features/SetpointSimple/SetpointSimpleForm.vue
+++ b/src/plugins/spark/features/SetpointSimple/SetpointSimpleForm.vue
@@ -26,9 +26,8 @@ export default class SetpointSimpleForm extends BlockForm {
     <q-card-section>
       <q-expansion-item default-opened group="modal" icon="settings" label="Settings">
         <q-item dark>
-          <q-item-section>
+          <q-item-section style="justify-content: flex-start">
             <q-item-label caption>Target</q-item-label>
-            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
             <UnitPopupEdit
               v-if="!isDriven"
               :class="{ darkened: block.data.setting.value === null }"
@@ -40,9 +39,10 @@ export default class SetpointSimpleForm extends BlockForm {
               v-else
               :class="{ darkened: block.data.setting.value === null }"
             >{{ block.data.setpoint | unit }}</big>
+            <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
           </q-item-section>
 
-          <q-item-section style="justify-content: space-between">
+          <q-item-section style="justify-content: flex-start">
             <q-item-label caption>Enabled</q-item-label>
             <q-toggle
               :value="block.data.enabled"

--- a/src/plugins/spark/features/SetpointSimple/SetpointSimpleWidget.vue
+++ b/src/plugins/spark/features/SetpointSimple/SetpointSimpleWidget.vue
@@ -48,10 +48,11 @@ export default class SetpointSimpleWidget extends BlockWidget {
             :change="callAndSaveBlock(v => block.data.setpoint = v)"
             label="Target"
           />
-          <big
+          <UnitField
             v-else
+            :field="block.data.setpoint"
             :class="{ darkened: block.data.setting.value === null }"
-          >{{ block.data.setpoint | unit }}</big>
+          />
           <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
         </q-item-section>
         <q-item-section>

--- a/src/plugins/spark/features/SetpointSimple/SetpointSimpleWidget.vue
+++ b/src/plugins/spark/features/SetpointSimple/SetpointSimpleWidget.vue
@@ -37,9 +37,10 @@ export default class SetpointSimpleWidget extends BlockWidget {
         </q-item-section>
         <q-item-section>This Setpoint is invalid</q-item-section>
       </q-item>
+
       <q-item dark>
-        <q-item-section>{{ block.data.enabled ? 'Target' : 'Target when enabled' }}</q-item-section>
         <q-item-section>
+          <q-item-label caption>{{ block.data.enabled ? 'Target' : 'Target when enabled' }}</q-item-label>
           <UnitPopupEdit
             v-if="!isDriven"
             :class="{ darkened: block.data.setting.value === null }"
@@ -53,10 +54,8 @@ export default class SetpointSimpleWidget extends BlockWidget {
           >{{ block.data.setpoint | unit }}</big>
           <DrivenIndicator :block-id="block.id" :service-id="serviceId"/>
         </q-item-section>
-      </q-item>
-      <q-item dark>
-        <q-item-section>Enabled</q-item-section>
         <q-item-section>
+          <q-item-label caption>Enabled</q-item-label>
           <q-toggle
             :value="block.data.enabled"
             @input="v => { block.data.enabled = v; saveBlock() }"

--- a/src/plugins/spark/features/TempSensorMock/TempSensorMockForm.vue
+++ b/src/plugins/spark/features/TempSensorMock/TempSensorMockForm.vue
@@ -25,8 +25,8 @@ export default class TempSensorMockForm extends BlockForm {
     <q-card-section>
       <q-expansion-item default-opened group="modal" icon="settings" label="Settings">
         <q-item dark>
-          <q-item-section>Value</q-item-section>
           <q-item-section>
+            <q-item-label caption>Value</q-item-label>
             <UnitPopupEdit
               :field="block.data.value"
               :disabled="!block.data.connected"
@@ -36,8 +36,8 @@ export default class TempSensorMockForm extends BlockForm {
           </q-item-section>
         </q-item>
         <q-item dark>
-          <q-item-section>Connected</q-item-section>
           <q-item-section>
+            <q-item-label caption>Connected</q-item-label>
             <q-toggle
               :value="block.data.connected"
               @input="v => { block.data.connected = v; saveBlock(); }"

--- a/src/plugins/spark/features/TempSensorMock/TempSensorMockWidget.vue
+++ b/src/plugins/spark/features/TempSensorMock/TempSensorMockWidget.vue
@@ -32,8 +32,8 @@ export default class TempSensorMockWidget extends BlockWidget {
 
     <q-card-section>
       <q-item dark>
-        <q-item-section>Value</q-item-section>
         <q-item-section>
+          <q-item-label caption>Value</q-item-label>
           <UnitPopupEdit
             :field="block.data.value"
             :disabled="!block.data.connected"
@@ -41,10 +41,8 @@ export default class TempSensorMockWidget extends BlockWidget {
             label="Value"
           />
         </q-item-section>
-      </q-item>
-      <q-item dark>
-        <q-item-section>Connected</q-item-section>
         <q-item-section>
+          <q-item-label caption>Connected</q-item-label>
           <q-toggle
             :value="block.data.connected"
             @input="v => { block.data.connected = v; saveBlock(); }"

--- a/src/plugins/spark/features/TempSensorOneWire/TempSensorOneWireForm.vue
+++ b/src/plugins/spark/features/TempSensorOneWire/TempSensorOneWireForm.vue
@@ -25,18 +25,16 @@ export default class TempSensorOneWireForm extends BlockForm {
     <q-card-section>
       <q-expansion-item default-opened group="modal" icon="settings" label="Settings">
         <q-item dark>
-          <q-item-section>Address</q-item-section>
           <q-item-section>
+            <q-item-label caption>Address</q-item-label>
             <InputPopupEdit
               :field="block.data.address"
               :change="callAndSaveBlock(v => block.data.address = v)"
               label="Address"
             />
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Offset</q-item-section>
           <q-item-section>
+            <q-item-label caption>Offset</q-item-label>
             <UnitPopupEdit
               :field="block.data.offset"
               :change="callAndSaveBlock(v => block.data.offset = v)"

--- a/src/plugins/spark/features/TempSensorOneWire/TempSensorOneWireWidget.vue
+++ b/src/plugins/spark/features/TempSensorOneWire/TempSensorOneWireWidget.vue
@@ -38,9 +38,12 @@ export default class TempSensorOneWireWidget extends BlockWidget {
         <q-item-section>This sensor is invalid</q-item-section>
       </q-item>
       <q-item v-else dark>
-        <q-item-section>Value</q-item-section>
         <q-item-section>
-          <big>{{ block.data.value | unit }}</big>
+          <q-item-label caption>Value</q-item-label>
+          <div>
+            <big>{{ block.data.value.val | round }}</big>
+            <span class="q-ml-xs">{{ block.data.value.notation }}</span>
+          </div>
         </q-item-section>
       </q-item>
     </q-card-section>

--- a/src/plugins/spark/features/TempSensorOneWire/TempSensorOneWireWidget.vue
+++ b/src/plugins/spark/features/TempSensorOneWire/TempSensorOneWireWidget.vue
@@ -40,10 +40,7 @@ export default class TempSensorOneWireWidget extends BlockWidget {
       <q-item v-else dark>
         <q-item-section>
           <q-item-label caption>Value</q-item-label>
-          <div>
-            <big>{{ block.data.value.val | round }}</big>
-            <span class="q-ml-xs">{{ block.data.value.notation }}</span>
-          </div>
+          <UnitField :field="block.data.value"/>
         </q-item-section>
       </q-item>
     </q-card-section>

--- a/src/plugins/spark/provider/SparkForm.vue
+++ b/src/plugins/spark/provider/SparkForm.vue
@@ -170,20 +170,30 @@ export default class SparkForm extends Vue {
     <q-card-section>
       <q-expansion-item group="modal" icon="info" label="System Info">
         <q-item dark>
-          <q-item-section>Device ID</q-item-section>
-          <q-item-section>{{ sysInfo.data.deviceId }}</q-item-section>
+          <q-item-section>
+            <q-item-label caption>Version</q-item-label>
+            <span>{{ sysInfo.data.version }}</span>
+          </q-item-section>
+          <q-item-section>
+            <q-item-label caption>IP address</q-item-label>
+            <span>{{ wifi.data.ip }}</span>
+          </q-item-section>
         </q-item>
         <q-item dark>
-          <q-item-section>Time since boot</q-item-section>
-          <q-item-section>{{ ticks.data.millisSinceBoot | duration }}</q-item-section>
+          <q-item-section>
+            <q-item-label caption>Device time</q-item-label>
+            <span>{{ sysDate }}</span>
+          </q-item-section>
+          <q-item-section>
+            <q-item-label caption>Time since boot</q-item-label>
+            <span>{{ ticks.data.millisSinceBoot | duration }}</span>
+          </q-item-section>
         </q-item>
         <q-item dark>
-          <q-item-section>Device time</q-item-section>
-          <q-item-section>{{ sysDate }}</q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Version</q-item-section>
-          <q-item-section>{{ sysInfo.data.version }}</q-item-section>
+          <q-item-section>
+            <q-item-label caption>Device ID</q-item-label>
+            <span style="word-wrap: break-word;">{{ sysInfo.data.deviceId }}</span>
+          </q-item-section>
         </q-item>
       </q-expansion-item>
 
@@ -196,32 +206,28 @@ export default class SparkForm extends Vue {
           />
         </q-dialog>
         <q-item dark>
-          <q-item-section>Network</q-item-section>
           <q-item-section>
-            <big
+            <q-item-label caption>Network</q-item-label>
+            <span
               class="editable"
               @click="wifiModal = true"
-            >{{ wifi.data.ssid || 'click to connect' }}</big>
+            >{{ wifi.data.ssid || 'click to connect' }}</span>
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Signal strength</q-item-section>
           <q-item-section>
-            <big>{{ signalPct }}%</big>
+            <q-item-label caption>IP address</q-item-label>
+            <span>{{ wifi.data.ip }}</span>
           </q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>IP address</q-item-section>
           <q-item-section>
-            <big>{{ wifi.data.ip }}</big>
+            <q-item-label caption>Signal strength</q-item-label>
+            <span>{{ signalPct }}%</span>
           </q-item-section>
         </q-item>
       </q-expansion-item>
 
       <q-expansion-item group="modal" icon="mdi-checkbox-multiple-marked" label="Groups">
         <q-item dark>
-          <q-item-section>Active groups</q-item-section>
           <q-item-section>
+            <q-item-label caption>Active groups</q-item-label>
             <GroupsPopupEdit
               :field="groups.data.active"
               :service-id="service.id"
@@ -229,58 +235,60 @@ export default class SparkForm extends Vue {
             />
           </q-item-section>
         </q-item>
-        <q-item dark>
-          <q-item-section side>Group names</q-item-section>
-          <q-item-section>
-            <q-item v-for="(name, idx) in groupNames" :key="idx" dark>
-              <q-item-section>{{ `Group ${idx + 1}` }}</q-item-section>
-              <q-item-section>
-                <InputPopupEdit
-                  :field="name"
-                  :change="v => { groupNames[idx] = v; saveGroupNames(); }"
-                  label="Group"
-                />
-              </q-item-section>
-            </q-item>
-          </q-item-section>
-        </q-item>
+
+        <div class="row">
+          <q-item v-for="(name, idx) in groupNames" :key="idx" dark class="col-4">
+            <q-item-section>
+              <q-item-label caption>{{ `Group ${idx + 1} name` }}</q-item-label>
+              <InputPopupEdit
+                :field="name"
+                :change="v => { groupNames[idx] = v; saveGroupNames(); }"
+                label="Group"
+                tag="span"
+              />
+            </q-item-section>
+          </q-item>
+        </div>
       </q-expansion-item>
 
       <q-expansion-item group="modal" icon="mdi-temperature-celsius" label="Units">
         <q-item dark>
-          <q-item-section side>Unit preferences</q-item-section>
-          <q-item-section>
-            <q-item v-for="(val, name) in units" :key="name" dark>
-              <q-item-section>{{ spaceCased(name) }}</q-item-section>
-              <q-item-section>
-                <SelectPopupEdit
-                  :field="val"
-                  :change="v => { units[name] = v; saveUnits(); }"
-                  :options="unitAlternativeOptions(name)"
-                  label="Preferred unit"
-                />
-              </q-item-section>
-            </q-item>
+          <q-item-section v-for="(val, name) in units" :key="name">
+            <q-item-label caption>{{ `${spaceCased(name)} unit` }}</q-item-label>
+            <SelectPopupEdit
+              :field="val"
+              :change="v => { units[name] = v; saveUnits(); }"
+              :options="unitAlternativeOptions(name)"
+              :label="`Preferred ${spaceCased(name)} unit`"
+              tag="span"
+            />
           </q-item-section>
         </q-item>
       </q-expansion-item>
 
-      <q-expansion-item group="modal" icon="mdi-magnify-plus-outline" label="Discovered Blocks">
+      <q-expansion-item
+        group="modal"
+        icon="mdi-magnify-plus-outline"
+        label="Discover new OneWire Blocks"
+      >
+        <q-item v-if="discoveredBlocks.length !== 0" dark dense>
+          <q-item-label caption>Recently discovered:</q-item-label>
+        </q-item>
+        <q-item v-for="id in discoveredBlocks" :key="id" :inset-level="1" dense dark>
+          <q-item-section>{{ id }}</q-item-section>
+        </q-item>
         <q-item dark>
           <q-item-section>
-            <q-btn outline label="Refresh" @click="fetchDiscoveredBlocks"/>
+            <q-btn outline label="Search for new devices" @click="fetchDiscoveredBlocks"/>
           </q-item-section>
           <q-item-section>
             <q-btn
               :disable="!discoveredBlocks.length"
               outline
-              label="Clear"
+              label="Clear recent"
               @click="clearDiscoveredBlocks"
             />
           </q-item-section>
-        </q-item>
-        <q-item v-for="id in discoveredBlocks" :key="id" :inset-level="1" dark>
-          <q-item-section>{{ id }}</q-item-section>
         </q-item>
       </q-expansion-item>
 

--- a/src/plugins/spark/provider/SparkWidget.vue
+++ b/src/plugins/spark/provider/SparkWidget.vue
@@ -93,26 +93,32 @@ export default class SparkWidget extends Vue {
         </q-item-section>
       </q-item>
 
-      <q-list dense>
+      <q-list>
         <q-item dark>
-          <q-item-section>Device ID</q-item-section>
-          <q-item-section style="word-wrap: break-word;">{{ sysInfo.data.deviceId }}</q-item-section>
+          <q-item-section>
+            <q-item-label caption>Version</q-item-label>
+            <span>{{ sysInfo.data.version }}</span>
+          </q-item-section>
+          <q-item-section>
+            <q-item-label caption>IP address</q-item-label>
+            <span>{{ wifi.data.ip }}</span>
+          </q-item-section>
         </q-item>
         <q-item dark>
-          <q-item-section>Time since boot</q-item-section>
-          <q-item-section>{{ ticks.data.millisSinceBoot | duration }}</q-item-section>
+          <q-item-section>
+            <q-item-label caption>Device time</q-item-label>
+            <span>{{ sysDate }}</span>
+          </q-item-section>
+          <q-item-section>
+            <q-item-label caption>Time since boot</q-item-label>
+            <span>{{ ticks.data.millisSinceBoot | duration }}</span>
+          </q-item-section>
         </q-item>
         <q-item dark>
-          <q-item-section>Device time</q-item-section>
-          <q-item-section>{{ sysDate }}</q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>Version</q-item-section>
-          <q-item-section>{{ sysInfo.data.version }}</q-item-section>
-        </q-item>
-        <q-item dark>
-          <q-item-section>IP address</q-item-section>
-          <q-item-section>{{ wifi.data.ip }}</q-item-section>
+          <q-item-section>
+            <q-item-label caption>Device ID</q-item-label>
+            <span style="word-wrap: break-word;">{{ sysInfo.data.deviceId }}</span>
+          </q-item-section>
         </q-item>
       </q-list>
     </q-card-section>


### PR DESCRIPTION
Restyled all widgets and forms to use more horizontal space and captions above fields instead of to their left.

Also included:
- Fixed bug in rounding function (brackets needed)
- Use labels above fields for widgets
- Fixed some rendering issues of constraints (component style didn't overrule quasar styling)
- Omit constraints label if no constraints are set in widget
- Clearer field names in forms

