### PR TITLE
Process View tools

### DIFF
--- a/dev/presets/dashboard-items.json
+++ b/dev/presets/dashboard-items.json
@@ -42,15 +42,6 @@
             "y": 2
           },
           {
-            "id": "b850ea97-4d09-66f6-c8eb-3287baee16c3",
-            "rotate": 90,
-            "settings": {},
-            "flipped": false,
-            "type": "SystemIO",
-            "x": 13,
-            "y": 1
-          },
-          {
             "id": "41693288-1161-ef12-bc7c-75d3b067e2f4",
             "rotate": 0,
             "settings": {},
@@ -242,6 +233,311 @@
             "x": 13,
             "y": 3,
             "type": "ElbowTube"
+          },
+          {
+            "id": "b850ea97-4d09-66f6-c8eb-3287baee16c3",
+            "rotate": 90,
+            "settings": {},
+            "flipped": false,
+            "type": "SystemIO",
+            "x": 13,
+            "y": 1
+          },
+          {
+            "id": "3271d456-4cfa-57b2-7172-cfe5ba68de0d",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
+            "type": "ImmersionCoil",
+            "x": 11,
+            "y": 14
+          },
+          {
+            "id": "e487af86-2886-3dc5-7925-3200a7b7bf03",
+            "rotate": 180,
+            "settings": {},
+            "flipped": false,
+            "type": "TeeTube",
+            "x": 11,
+            "y": 13
+          },
+          {
+            "id": "34355c2d-5dd0-aa1f-6708-92f085bfd42a",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
+            "type": "CrossTube",
+            "x": 12,
+            "y": 13
+          },
+          {
+            "id": "9b308893-554c-e3c8-e4d8-f948a4da7466",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
+            "type": "Lauterhexe",
+            "x": 13,
+            "y": 13
+          },
+          {
+            "id": "7ce17e1b-1784-4502-a449-d665479392a3",
+            "rotate": 90,
+            "settings": {},
+            "flipped": false,
+            "type": "ElbowTube",
+            "x": 12,
+            "y": 12
+          },
+          {
+            "id": "203f9fc0-0887-d409-2e58-ba4a070dfabe",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
+            "type": "CounterflowChiller",
+            "x": 13,
+            "y": 11
+          },
+          {
+            "id": "d9cfc2bf-ac59-e765-0fbc-7644d44810f1",
+            "rotate": 0,
+            "settings": {
+              "disabled": false
+            },
+            "flipped": false,
+            "x": 16,
+            "y": 12,
+            "type": "Pump",
+            "disabled": false
+          },
+          {
+            "id": "44f308d1-1d04-f65e-c89d-e7318ec05786",
+            "rotate": 270,
+            "settings": {},
+            "flipped": false,
+            "type": "ElbowTube",
+            "x": 17,
+            "y": 12
+          },
+          {
+            "id": "529b1781-1d94-cdd6-40b6-2023739cf67a",
+            "rotate": 180,
+            "settings": {},
+            "flipped": false,
+            "type": "ElbowTube",
+            "x": 17,
+            "y": 11
+          },
+          {
+            "id": "5b70b4c9-5851-ed39-9358-752fc1186c6a",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
+            "x": 16,
+            "y": 11,
+            "type": "StraightTube"
+          },
+          {
+            "id": "9fa9e091-2fb1-9732-7683-deb741ce044f",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
+            "type": "ElbowTube",
+            "x": 12,
+            "y": 11
+          },
+          {
+            "id": "bc2c9d81-18bf-425d-4cf4-2a3d621ee9ee",
+            "rotate": 90,
+            "settings": {},
+            "flipped": false,
+            "type": "WhirlpoolInlet",
+            "x": 10,
+            "y": 14
+          },
+          {
+            "id": "1d26dd0b-4876-d624-e80c-d9c2a723303f",
+            "rotate": 180,
+            "settings": {},
+            "flipped": false,
+            "type": "TeeTube",
+            "x": 10,
+            "y": 13
+          },
+          {
+            "id": "ed6adaf3-3889-04eb-1855-8dc48b78cfd7",
+            "rotate": 0,
+            "settings": {
+              "closed": true,
+              "actuatorLink": null
+            },
+            "flipped": false,
+            "type": "ActuatorValve",
+            "x": 9,
+            "y": 13
+          },
+          {
+            "id": "6fb9403b-4174-cc32-27b8-355c3071473f",
+            "rotate": 180,
+            "settings": {},
+            "flipped": false,
+            "type": "DipTube",
+            "x": 8,
+            "y": 13
+          },
+          {
+            "id": "3f3b54c8-7fee-e0f1-4eb7-ed083a313674",
+            "rotate": 90,
+            "settings": {},
+            "flipped": false,
+            "type": "TeeTube",
+            "x": 12,
+            "y": 10
+          },
+          {
+            "id": "e967b812-63dc-87f6-75c9-9b6d39d3919c",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
+            "type": "CheckValve",
+            "x": 13,
+            "y": 10
+          },
+          {
+            "id": "4c957508-a8c6-f899-360d-ee2e434d2708",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
+            "x": 14,
+            "y": 10,
+            "type": "StraightTube"
+          },
+          {
+            "id": "26f7c494-bf52-efcf-401c-5e2a2d9b22b5",
+            "rotate": 180,
+            "settings": {
+              "liquids": [
+                "#DB0023"
+              ]
+            },
+            "flipped": false,
+            "type": "SystemIO",
+            "x": 15,
+            "y": 10
+          },
+          {
+            "id": "4cfac8d4-e613-faae-4819-2409d597d7e1",
+            "rotate": 90,
+            "settings": {},
+            "flipped": false,
+            "type": "TeeTube",
+            "x": 12,
+            "y": 9
+          },
+          {
+            "id": "e349cdd1-73f8-4a51-e8ee-bc593707d5c7",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
+            "type": "StraightInletTube",
+            "x": 13,
+            "y": 9
+          },
+          {
+            "id": "11383259-3d68-8143-3737-5cd390f258b8",
+            "rotate": 90,
+            "settings": {},
+            "flipped": false,
+            "type": "TeeTube",
+            "x": 12,
+            "y": 8
+          },
+          {
+            "id": "35aeca63-e1db-b49a-830c-356fc31a0bdc",
+            "rotate": 180,
+            "settings": {},
+            "flipped": false,
+            "type": "CheckValve",
+            "x": 13,
+            "y": 8
+          },
+          {
+            "id": "a009f479-2c09-d8e6-6979-e218ee9cb8f4",
+            "rotate": 180,
+            "settings": {
+              "liquids": [
+                "#DB0023"
+              ]
+            },
+            "flipped": false,
+            "type": "SystemIO",
+            "x": 14,
+            "y": 8
+          },
+          {
+            "id": "257f8b02-c8cf-eb7d-361e-64353976588c",
+            "rotate": 90,
+            "settings": {},
+            "flipped": false,
+            "type": "ElbowTube",
+            "x": 12,
+            "y": 7
+          },
+          {
+            "id": "0907e793-bc39-7c63-c22a-6ee15a535aed",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
+            "type": "Coil",
+            "x": 13,
+            "y": 6
+          },
+          {
+            "id": "6bbb153e-12dc-7ee5-516d-0cc365da8e26",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
+            "type": "ElbowTube",
+            "x": 12,
+            "y": 6
+          },
+          {
+            "id": "60563139-095a-1ed0-9cd8-ed27de9def6d",
+            "rotate": 90,
+            "settings": {
+              "liquids": [
+                "#4AA0EF"
+              ],
+              "pressure": 10
+            },
+            "flipped": false,
+            "x": 12,
+            "y": 5,
+            "type": "SystemIO"
+          },
+          {
+            "id": "b9b9da24-337c-4d66-e234-46d3688d6d1f",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
+            "type": "HeatingElement",
+            "x": 7,
+            "y": 11
+          },
+          {
+            "id": "4751b204-56b8-f26d-d894-6b845e73e71a",
+            "rotate": 0,
+            "settings": {
+              "sensorServiceId": "sparkey",
+              "sensorLink": {
+                "id": "sensor-1",
+                "type": "TempSensorMock",
+                "driven": false
+              }
+            },
+            "flipped": false,
+            "type": "SensorDisplay",
+            "x": 17,
+            "y": 9
           }
         ]
       }

--- a/dev/presets/dashboard-items.json
+++ b/dev/presets/dashboard-items.json
@@ -11,168 +11,237 @@
       "config": {
         "parts": [
           {
-            "x": 11,
-            "y": 2,
-            "type": "SystemIO",
+            "id": "cb0bdf02-5cd0-c29e-ddbf-6537762fbc77",
             "rotate": 0,
             "settings": {
               "liquids": [
                 "#C678DD"
               ]
-            }
+            },
+            "flipped": false,
+            "x": 11,
+            "y": 2,
+            "type": "SystemIO"
           },
           {
+            "id": "e0929a70-22cd-f34b-ffe9-7060016a0cf2",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
             "x": 12,
             "y": 2,
-            "type": "StraightTube",
-            "rotate": 0
+            "type": "StraightTube"
           },
           {
+            "id": "0c506a71-af93-44b6-dbe0-c4ab16f7d80b",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
             "type": "BridgeTube",
             "x": 13,
-            "y": 2,
-            "rotate": 0
+            "y": 2
           },
           {
+            "id": "b850ea97-4d09-66f6-c8eb-3287baee16c3",
+            "rotate": 90,
+            "settings": {},
+            "flipped": false,
             "type": "SystemIO",
             "x": 13,
-            "y": 1,
-            "rotate": 90
+            "y": 1
           },
           {
+            "id": "41693288-1161-ef12-bc7c-75d3b067e2f4",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
             "x": 14,
             "y": 2,
-            "type": "Coil",
-            "rotate": 0
+            "type": "Coil"
           },
           {
-            "x": 13,
-            "y": 3,
-            "type": "ElbowTube",
-            "rotate": 0
-          },
-          {
-            "type": "SystemIO",
-            "x": 0,
-            "y": 2,
+            "id": "ef649e86-967a-8e81-3139-f7bcc61e462c",
             "rotate": 0,
             "settings": {
               "liquids": [
                 "#4AA0EF"
               ],
               "pressure": 10
-            }
+            },
+            "flipped": false,
+            "type": "SystemIO",
+            "x": 0,
+            "y": 2
           },
           {
+            "id": "56565652-dba8-b68a-ee0c-66534dfbda20",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
             "type": "Valve",
             "x": 1,
-            "y": 2,
-            "rotate": 0
+            "y": 2
           },
           {
+            "id": "f4b935cd-4ae5-823b-de60-524931bd7a1b",
+            "rotate": 270,
+            "settings": {},
+            "flipped": false,
             "x": 3,
             "y": 6,
-            "type": "SystemIO",
-            "rotate": 270
+            "type": "SystemIO"
           },
           {
+            "id": "72163643-aea3-24f0-e898-ac100e1fb0ff",
+            "rotate": 90,
+            "settings": {},
+            "flipped": false,
             "type": "Valve",
             "x": 3,
             "y": 5,
-            "rotate": 90,
             "closed": false
           },
           {
+            "id": "d42cca9b-1d9c-322c-1456-e2c630bf47d8",
+            "rotate": 180,
+            "settings": {},
+            "flipped": false,
             "x": 3,
             "y": 4,
-            "type": "TeeTube",
-            "rotate": 180
+            "type": "TeeTube"
           },
           {
+            "id": "e5561b25-0ace-1590-f9b6-524287b2791f",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
             "type": "ElbowTube",
             "x": 2,
-            "y": 4,
-            "rotate": 0
+            "y": 4
           },
           {
+            "id": "2f27d35e-ed31-8869-26a1-883c2942fab4",
+            "rotate": 90,
+            "settings": {},
+            "flipped": false,
             "type": "TeeTube",
             "x": 2,
-            "y": 3,
-            "rotate": 90
+            "y": 3
           },
           {
+            "id": "8daa8de7-46c1-b3ec-6f6d-d4196dab4d58",
+            "rotate": 180,
+            "settings": {},
+            "flipped": false,
             "x": 2,
             "y": 2,
-            "type": "TeeTube",
-            "rotate": 180
+            "type": "TeeTube"
           },
           {
+            "id": "124810ca-69aa-81e0-f770-d0adac8e74a0",
+            "rotate": 270,
+            "settings": {},
+            "flipped": false,
             "type": "ElbowTube",
             "x": 3,
-            "y": 3,
-            "rotate": 270
+            "y": 3
           },
           {
+            "id": "47cf3706-001d-36f0-d079-6ba396c74f57",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
             "type": "BridgeTube",
             "x": 3,
-            "y": 2,
-            "rotate": 0
+            "y": 2
           },
           {
+            "id": "0081f539-a5a1-74dd-5ae3-252c988b46cc",
+            "rotate": 270,
+            "settings": {},
+            "flipped": false,
             "x": 5,
             "y": 4,
-            "type": "ElbowTube",
-            "rotate": 270
+            "type": "ElbowTube"
           },
           {
-            "type": "SystemIO",
-            "x": 7,
-            "y": 3,
+            "id": "f07773c1-bfdd-2b67-5fb0-131a4761ff02",
             "rotate": 180,
             "settings": {
               "liquids": [
                 "#DB0023"
               ]
-            }
+            },
+            "flipped": false,
+            "type": "SystemIO",
+            "x": 7,
+            "y": 3
           },
           {
+            "id": "7a14dfd2-9883-60ab-c6dc-346a1a4a6ced",
+            "rotate": 180,
+            "settings": {},
+            "flipped": false,
             "type": "Valve",
             "x": 6,
             "y": 3,
-            "rotate": 180,
             "closed": false
           },
           {
+            "id": "d5294a3c-5c27-5381-9fdb-42e7fd7ea1b3",
+            "rotate": 90,
+            "settings": {},
+            "flipped": false,
             "type": "TeeTube",
             "x": 5,
-            "y": 3,
-            "rotate": 90
+            "y": 3
           },
           {
+            "id": "73620c5c-917a-f58d-324a-bdf279ba32ab",
+            "rotate": 180,
+            "settings": {},
+            "flipped": false,
             "type": "ElbowTube",
             "x": 5,
-            "y": 2,
-            "rotate": 180
+            "y": 2
           },
           {
+            "id": "0f61648a-e83b-d4a5-12e8-82da479b74fb",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
             "x": 4,
             "y": 2,
             "type": "Pump",
-            "rotate": 0,
             "disabled": false
           },
           {
+            "id": "6573658f-087f-277c-f445-faaa18d39556",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
             "type": "Valve",
             "x": 4,
             "y": 4,
-            "rotate": 0,
             "closed": true
           },
           {
+            "id": "1edc48e0-bb24-23a5-741d-68e996b4f3d9",
+            "rotate": 90,
+            "settings": {},
+            "flipped": false,
             "type": "SystemIO",
             "x": 3,
-            "y": 1,
-            "rotate": 90
+            "y": 1
+          },
+          {
+            "id": "c7652ea7-923b-7c76-c032-9bcb0411b9d6",
+            "rotate": 0,
+            "settings": {},
+            "flipped": false,
+            "x": 13,
+            "y": 3,
+            "type": "ElbowTube"
           }
         ]
       }

--- a/src/components/PopupEdit/TimeUnitPopupEdit.vue
+++ b/src/components/PopupEdit/TimeUnitPopupEdit.vue
@@ -2,7 +2,7 @@
 import { Unit } from '@/helpers/units';
 import Vue from 'vue';
 import Component from 'vue-class-component';
-import { durationString, unitDurationString } from '@/helpers/functional';
+import { unitDurationString } from '@/helpers/functional';
 import parseDuration from 'parse-duration';
 
 @Component({

--- a/src/components/Widget/ActionItem.vue
+++ b/src/components/Widget/ActionItem.vue
@@ -12,13 +12,17 @@ import Vue from 'vue';
       type: String,
       required: false,
     },
+    active: {
+      type: Boolean,
+      default: false,
+    },
   },
 })
 export default class ActionItem extends Vue { }
 </script>
 
 <template>
-  <q-item v-close-popup dark clickable @click="$emit('click')">
+  <q-item v-close-popup :active="$props.active" dark clickable @click="$emit('click')">
     <q-item-section v-if="$props.icon" avatar>
       <q-icon :name="$props.icon"/>
     </q-item-section>

--- a/src/helpers/functional.ts
+++ b/src/helpers/functional.ts
@@ -129,3 +129,13 @@ export function valOrDefault<T>(val: T, defaultVal: T): T {
     ? val
     : defaultVal;
 }
+
+export function chunked<T>(arr: T[], chunkSize: number): T[][] {
+  let chunks: T[][] = [];
+  let i = 0;
+  const n = arr.length;
+  while (i < n) {
+    chunks.push(arr.slice(i, i += chunkSize));
+  }
+  return chunks;
+}

--- a/src/plugins/spark/features/DS2413/DS2413Form.vue
+++ b/src/plugins/spark/features/DS2413/DS2413Form.vue
@@ -33,7 +33,10 @@ export default class DS2413Form extends BlockForm {
       <q-item dark>
         <q-item-section>
           <q-item-label caption>Note</q-item-label>
-          <span>This block is the DS2413 chip with 2 channels. Please create a DS2413 Actuator block for each of the channels you want to use.</span>
+          <span>
+            This block is the DS2413 chip with 2 channels.
+            Please create a DS2413 Actuator block for each of the channels you want to use.
+          </span>
         </q-item-section>
       </q-item>
 

--- a/src/plugins/spark/features/ProcessView/ProcessViewCatalog.vue
+++ b/src/plugins/spark/features/ProcessView/ProcessViewCatalog.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import Component from 'vue-class-component';
+import { uid } from 'quasar';
 import { SQUARE_SIZE } from './getters';
 import { parts } from './register';
 import settings from './settings';
@@ -24,6 +25,7 @@ export default class ProcessViewCatalog extends Vue {
     return parts
       .map(type => ({
         type,
+        id: uid(),
         x: -2,
         y: -2,
         rotate: 0,

--- a/src/plugins/spark/features/ProcessView/ProcessViewCatalog.vue
+++ b/src/plugins/spark/features/ProcessView/ProcessViewCatalog.vue
@@ -1,0 +1,75 @@
+<script lang="ts">
+import Vue from 'vue';
+import Component from 'vue-class-component';
+import { SQUARE_SIZE } from './getters';
+import { parts } from './register';
+import settings from './settings';
+import { PersistentPart } from './state';
+import { spaceCased } from '@/helpers/functional';
+
+
+@Component({
+  props: {
+    partial: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+})
+export default class ProcessViewCatalog extends Vue {
+  SQUARE_SIZE: number = SQUARE_SIZE;
+  spaceCased = spaceCased;
+
+  get availableParts(): PersistentPart[] {
+    return parts
+      .map(type => ({
+        type,
+        x: -2,
+        y: -2,
+        rotate: 0,
+        settings: {},
+        flipped: false,
+      }));
+  }
+
+  partViewBox(part: PersistentPart): string {
+    return settings[part.type].size(part).map(v => v * SQUARE_SIZE).join(' ');
+  }
+
+  selectPart(part: PersistentPart) {
+    this.$emit('create', { ...part, ...this.$props.partial });
+    this.$nextTick(() => this.$emit('close'));
+  }
+}
+</script>
+
+<template>
+  <q-card dark class="widget-modal">
+    <FormToolbar>Part Catalog</FormToolbar>
+
+    <q-scroll-area style="min-height: 400px; height: 60vh;">
+      <q-card-section>
+        <q-list style="padding: 5px">
+          <q-item
+            v-for="part in availableParts"
+            :key="part.type"
+            dark
+            clickable
+            @click="selectPart(part)"
+          >
+            <q-item-section side>
+              <svg
+                :width="`${SQUARE_SIZE}px`"
+                :height="`${SQUARE_SIZE}px`"
+                :viewBox="`0 0 ${partViewBox(part)}`"
+              >
+                <ProcessViewItem :value="part"/>
+              </svg>
+            </q-item-section>
+            <q-item-section>{{ spaceCased(part.type) }}</q-item-section>
+          </q-item>
+        </q-list>
+      </q-card-section>
+    </q-scroll-area>
+  </q-card>
+</template>

--- a/src/plugins/spark/features/ProcessView/ProcessViewForm.vue
+++ b/src/plugins/spark/features/ProcessView/ProcessViewForm.vue
@@ -24,7 +24,10 @@ export default class ProcessViewForm extends Vue {
   }
 
   get cards() {
-    return partSettings(this.part).cards;
+    return [
+      'PlacementPartCard',
+      ...partSettings(this.part).cards,
+    ];
   }
 
   get partSize(): [number, number] {
@@ -89,9 +92,7 @@ export default class ProcessViewForm extends Vue {
             :viewBox="partViewBox"
             class="q-mx-auto"
           >
-            <g>
-              <ProcessViewItem :value="part"/>
-            </g>
+            <ProcessViewItem :value="part"/>
           </svg>
         </q-item-section>
       </q-item>
@@ -99,10 +100,3 @@ export default class ProcessViewForm extends Vue {
     </q-card-section>
   </q-card>
 </template>
-
-<style scoped>
-.q-card {
-  width: 100%;
-  margin-bottom: 10px;
-}
-</style>

--- a/src/plugins/spark/features/ProcessView/ProcessViewForm.vue
+++ b/src/plugins/spark/features/ProcessView/ProcessViewForm.vue
@@ -24,10 +24,7 @@ export default class ProcessViewForm extends Vue {
   }
 
   get cards() {
-    return [
-      'PlacementPartCard',
-      ...partSettings(this.part).cards,
-    ];
+    return partSettings(this.part).cards;
   }
 
   get partSize(): [number, number] {

--- a/src/plugins/spark/features/ProcessView/ProcessViewWidget.vue
+++ b/src/plugins/spark/features/ProcessView/ProcessViewWidget.vue
@@ -59,11 +59,19 @@ export default class ProcessViewWidget extends WidgetBase {
   titleModel: string = '';
   dragAction: DragAction | null = null;
   configuredPartId: string | null = null;
-  currentTool: ToolAction = this.tools[0];
-  catalogPartial: Partial<PersistentPart> | null = null
+  catalogPartial: Partial<PersistentPart> | null = null;
 
   get widgetConfig(): ProcessViewConfig {
     return this.$props.config;
+  }
+
+  get currentTool(): ToolAction {
+    const toolId = this.widgetConfig.currentToolId;
+    return this.tools.find(tool => tool.value === toolId) || this.tools[0];
+  }
+
+  set currentTool(tool: ToolAction) {
+    this.saveConfig({ ...this.widgetConfig, currentToolId: tool.value });
   }
 
   saveConfig(config: ProcessViewConfig = this.widgetConfig) {
@@ -132,10 +140,28 @@ export default class ProcessViewWidget extends WidgetBase {
   get tools(): ToolAction[] {
     return [
       {
+        label: 'New (Click)',
+        value: 'add',
+        icon: 'add',
+        onClick: this.addPartClickHandler,
+      },
+      {
         label: 'Move (Drag)',
         value: 'move',
         icon: 'mdi-cursor-move',
         onPan: this.movePanHandler,
+      },
+      {
+        label: 'Rotate (Click)',
+        value: 'rotate-right',
+        icon: 'mdi-rotate-right-variant',
+        onClick: (evt, part) => this.rotateClickHandler(evt, part, 90),
+      },
+      {
+        label: 'Edit Settings (Click)',
+        value: 'config',
+        icon: 'settings',
+        onClick: this.configurePartClickHandler,
       },
       {
         label: 'Copy (Drag)',
@@ -144,31 +170,7 @@ export default class ProcessViewWidget extends WidgetBase {
         onPan: this.copyPanHandler,
       },
       {
-        label: 'New (Click)',
-        value: 'add',
-        icon: 'add',
-        onClick: this.addPartClickHandler,
-      },
-      {
-        label: 'Configure (Click)',
-        value: 'config',
-        icon: 'settings',
-        onClick: this.configurePartClickHandler,
-      },
-      {
-        label: 'Rotate left (Click)',
-        value: 'rotate-left',
-        icon: 'mdi-rotate-left-variant',
-        onClick: (evt, part) => this.rotateClickHandler(evt, part, -90),
-      },
-      {
-        label: 'Rotate right (Click)',
-        value: 'rotate-right',
-        icon: 'mdi-rotate-right-variant',
-        onClick: (evt, part) => this.rotateClickHandler(evt, part, 90),
-      },
-      {
-        label: 'Remove (Click)',
+        label: 'Delete (Click)',
         value: 'delete',
         icon: 'delete',
         onClick: (evt, part) => this.removePart(part),

--- a/src/plugins/spark/features/ProcessView/ProcessViewWidget.vue
+++ b/src/plugins/spark/features/ProcessView/ProcessViewWidget.vue
@@ -399,7 +399,7 @@ export default class ProcessViewWidget extends WidgetBase {
     <q-card-section v-if="editable" class="q-py-none">
       <q-item dark dense class="justify-around">
         <q-item-section class="col-auto">
-          <q-btn-dropdown :label="currentTool.label" flat>
+          <q-btn-dropdown :icon="currentTool.icon" :label="currentTool.label" flat>
             <q-list dark bordered>
               <ActionItem
                 v-for="tool in tools"

--- a/src/plugins/spark/features/ProcessView/ProcessViewWidget.vue
+++ b/src/plugins/spark/features/ProcessView/ProcessViewWidget.vue
@@ -61,7 +61,13 @@ export default class ProcessViewWidget extends WidgetBase {
   }
 
   updateParts(parts: PersistentPart[]) {
-    this.saveConfig({ ...this.widgetConfig, parts });
+    const asPersistent = (part: PersistentPart | FlowPart) => {
+      /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+      const { transitions, flows, ...persistent } = part as FlowPart;
+      return persistent;
+    };
+
+    this.saveConfig({ ...this.widgetConfig, parts: parts.map(asPersistent) });
   }
 
   updatePart(part: PersistentPart | FlowPart) {
@@ -223,7 +229,7 @@ export default class ProcessViewWidget extends WidgetBase {
         const id = copy ? uid() : part.id;
         this.movePart(from, { ...part, ...gridPos, id });
       }
-      this.dragAction = null;
+      this.$nextTick(() => this.dragAction = null);
     }
   }
 

--- a/src/plugins/spark/features/ProcessView/calculateFlows.ts
+++ b/src/plugins/spark/features/ProcessView/calculateFlows.ts
@@ -18,10 +18,6 @@ import mapKeys from 'lodash/mapKeys';
 import pickBy from 'lodash/pickBy';
 import omit from 'lodash/omit';
 
-export const isSamePart =
-  (left: PersistentPart, right: PersistentPart): boolean =>
-    ['x', 'y', 'type', 'rotate'].every(k => left && right && left[k] === right[k]);
-
 export const removeTransitions =
   (parts: FlowPart[], inCoord: string): FlowPart[] => parts.map(
     part => ({ ...part, transitions: omit(part.transitions, inCoord) }));
@@ -48,7 +44,7 @@ const adjacentPart = (
 ): FlowPart | undefined =>
   allParts
     .find((part: FlowPart) =>
-      !(currentPart && isSamePart(part, currentPart))
+      !(currentPart && part.id === currentPart.id)
       && has(part, ['transitions', outCoords]));
 
 const normalizeFlows = (part: FlowPart): FlowPart => {
@@ -168,7 +164,7 @@ const additionalFlow = (
 ): FlowPart[] =>
   allParts
     .map((item) =>
-      isSamePart(part, item)
+      part.id === item.id
         ? { ...item, flows: combineFlows(item.flows, flowToAdd) }
         : item);
 
@@ -298,7 +294,7 @@ export const flowPath = (
         break;
       }
       candidateParts = candidateParts
-        .filter(part => nextPart && !isSamePart(nextPart, part));
+        .filter(part => nextPart && !(nextPart.id === part.id));
     }
   };
   if (path.transitions[inCoord] === undefined) {

--- a/src/plugins/spark/features/ProcessView/calculateFlows.ts
+++ b/src/plugins/spark/features/ProcessView/calculateFlows.ts
@@ -20,7 +20,7 @@ import omit from 'lodash/omit';
 
 export const isSamePart =
   (left: PersistentPart, right: PersistentPart): boolean =>
-    ['x', 'y', 'type', 'rotate'].every(k => left[k] === right[k]);
+    ['x', 'y', 'type', 'rotate'].every(k => left && right && left[k] === right[k]);
 
 export const removeTransitions =
   (parts: FlowPart[], inCoord: string): FlowPart[] => parts.map(

--- a/src/plugins/spark/features/ProcessView/state.d.ts
+++ b/src/plugins/spark/features/ProcessView/state.d.ts
@@ -42,5 +42,6 @@ export interface FlowPart extends PersistentPart {
 }
 
 export interface ProcessViewConfig {
+  currentToolId?: string;
   parts: PersistentPart[];
 }

--- a/src/plugins/spark/features/ProcessView/state.d.ts
+++ b/src/plugins/spark/features/ProcessView/state.d.ts
@@ -20,6 +20,7 @@ export interface CalculatedFlows {
 }
 
 export interface PersistentPart {
+  id: string;
   type: string;
   x: number;
   y: number;

--- a/tests/unit/calculateFlows.test.ts
+++ b/tests/unit/calculateFlows.test.ts
@@ -54,7 +54,6 @@ describe('Data describing an input tube', () => {
 describe('asFlowParts', () => {
   const path: PersistentPart[] = [
     {
-
       x: 1,
       y: 2,
       rotate: 0,
@@ -71,7 +70,6 @@ describe('asFlowParts', () => {
       settings: {},
     },
     {
-
       x: 3,
       y: 2,
       rotate: 0,
@@ -101,7 +99,6 @@ describe('A single path without splits', () => {
       },
     },
     {
-
       x: 3,
       y: 2,
       rotate: 180,
@@ -200,7 +197,6 @@ describe('A single path without splits', () => {
 describe('A path with a split, but no joins', () => {
   const parts: PersistentPart[] = [
     {
-
       x: 1,
       y: 2,
       rotate: 0,
@@ -270,23 +266,23 @@ describe('A path with a split, but no joins', () => {
     expect(transitions).toEqual(
       [
         {
-          [IN_OUT]: [{ outCoords: "2,2.5", pressure: 14, liquids: [COLD_WATER] }],
+          [IN_OUT]: [{ outCoords: '2,2.5', pressure: 14, liquids: [COLD_WATER] }],
         },
         {
-          "2,2.5": [{ outCoords: "3,2.5" }],
+          '2,2.5': [{ outCoords: '3,2.5' }],
         },
         {
-          "3,2.5": [{ outCoords: "3.5,2" }, { outCoords: "3.5,3" }],
+          '3,2.5': [{ outCoords: '3.5,2' }, { outCoords: '3.5,3' }],
         },
         [
           [
             {
-              "3.5,2": [{ outCoords: IN_OUT }],
+              '3.5,2': [{ outCoords: IN_OUT }],
             },
           ],
           [
             {
-              "3.5,3": [{ outCoords: IN_OUT }],
+              '3.5,3': [{ outCoords: IN_OUT }],
             },
           ],
         ],
@@ -303,10 +299,10 @@ describe('A path with a split, but no joins', () => {
       [
         {
           flows: {
-            "-1,-1": {
+            '-1,-1': {
               [COLD_WATER]: -4,
             },
-            "2,2.5": {
+            '2,2.5': {
               [COLD_WATER]: 4,
             },
           },
@@ -314,10 +310,10 @@ describe('A path with a split, but no joins', () => {
         },
         {
           flows: {
-            "2,2.5": {
+            '2,2.5': {
               [COLD_WATER]: -4,
             },
-            "3,2.5": {
+            '3,2.5': {
               [COLD_WATER]: 4,
             },
           },
@@ -325,13 +321,13 @@ describe('A path with a split, but no joins', () => {
         },
         {
           flows: {
-            "3,2.5": {
+            '3,2.5': {
               [COLD_WATER]: -4,
             },
-            "3.5,2": {
+            '3.5,2': {
               [COLD_WATER]: 2,
             },
-            "3.5,3": {
+            '3.5,3': {
               [COLD_WATER]: 2,
             },
           },
@@ -339,10 +335,10 @@ describe('A path with a split, but no joins', () => {
         },
         {
           flows: {
-            "-1,-1": {
+            '-1,-1': {
               [COLD_WATER]: 2,
             },
-            "3.5,2": {
+            '3.5,2': {
               [COLD_WATER]: -2,
             },
           },
@@ -352,10 +348,10 @@ describe('A path with a split, but no joins', () => {
         },
         {
           flows: {
-            "-1,-1": {
+            '-1,-1': {
               [COLD_WATER]: 2,
             },
-            "3.5,3": {
+            '3.5,3': {
               [COLD_WATER]: -2,
             },
           },
@@ -471,22 +467,22 @@ describe('A path that forks and rejoins', () => {
     const transitions = propertyWalker([], path, ['transitions']);
     expect(transitions).toEqual(
       [
-        { [IN_OUT]: [{ outCoords: "2,2.5", pressure: 11, liquids: [COLD_WATER] }] },
-        { "2,2.5": [{ outCoords: "3,2.5" }] },
-        { "3,2.5": [{ outCoords: "3.5,2" }, { outCoords: "3.5,3" }] },
+        { [IN_OUT]: [{ outCoords: '2,2.5', pressure: 11, liquids: [COLD_WATER] }] },
+        { '2,2.5': [{ outCoords: '3,2.5' }] },
+        { '3,2.5': [{ outCoords: '3.5,2' }, { outCoords: '3.5,3' }] },
         [
           [
-            { "3.5,2": [{ outCoords: "4,1.5" }] },
-            { "4,1.5": [{ outCoords: "4.5,2" }] },
-            { "4.5,2": [{ outCoords: "5,2.5" }] },
+            { '3.5,2': [{ outCoords: '4,1.5' }] },
+            { '4,1.5': [{ outCoords: '4.5,2' }] },
+            { '4.5,2': [{ outCoords: '5,2.5' }] },
           ],
           [
-            { "3.5,3": [{ outCoords: "4,3.5" }] },
-            { "4,3.5": [{ outCoords: "4.5,3" }] },
-            { "4.5,3": [{ outCoords: "5,2.5" }] },
+            { '3.5,3': [{ outCoords: '4,3.5' }] },
+            { '4,3.5': [{ outCoords: '4.5,3' }] },
+            { '4.5,3': [{ outCoords: '5,2.5' }] },
           ],
         ],
-        { "5,2.5": [{ outCoords: IN_OUT }] },
+        { '5,2.5': [{ outCoords: IN_OUT }] },
       ]);
   });
 
@@ -500,67 +496,67 @@ describe('A path that forks and rejoins', () => {
       [
         {
           flows: {
-            "-1,-1": { [COLD_WATER]: -2 },
-            "2,2.5": { [COLD_WATER]: 2 },
+            '-1,-1': { [COLD_WATER]: -2 },
+            '2,2.5': { [COLD_WATER]: 2 },
           },
           type: 'SystemIO',
         },
         {
           flows: {
-            "2,2.5": { [COLD_WATER]: -2 },
-            "3,2.5": { [COLD_WATER]: 2 },
+            '2,2.5': { [COLD_WATER]: -2 },
+            '3,2.5': { [COLD_WATER]: 2 },
           },
           type: 'StraightTube',
         },
         {
           flows: {
-            "3,2.5": { [COLD_WATER]: -2 },
-            "3.5,2": { [COLD_WATER]: 1 },
-            "3.5,3": { [COLD_WATER]: 1 },
+            '3,2.5': { [COLD_WATER]: -2 },
+            '3.5,2': { [COLD_WATER]: 1 },
+            '3.5,3': { [COLD_WATER]: 1 },
           },
           type: 'TeeTube',
 
         },
         {
           flows: {
-            "3.5,2": { [COLD_WATER]: -1 },
-            "4,1.5": { [COLD_WATER]: 1 },
+            '3.5,2': { [COLD_WATER]: -1 },
+            '4,1.5': { [COLD_WATER]: 1 },
           },
           type: 'ElbowTube',
         },
         {
           flows: {
-            "3.5,3": { [COLD_WATER]: -1 },
-            "4,3.5": { [COLD_WATER]: 1 },
+            '3.5,3': { [COLD_WATER]: -1 },
+            '4,3.5': { [COLD_WATER]: 1 },
           },
           type: 'ElbowTube',
         },
         {
           flows: {
-            "4,1.5": { [COLD_WATER]: -1 },
-            "4.5,2": { [COLD_WATER]: 1 },
+            '4,1.5': { [COLD_WATER]: -1 },
+            '4.5,2': { [COLD_WATER]: 1 },
           },
           type: 'ElbowTube',
         },
         {
           flows: {
-            "4,3.5": { [COLD_WATER]: -1 },
-            "4.5,3": { [COLD_WATER]: 1 },
+            '4,3.5': { [COLD_WATER]: -1 },
+            '4.5,3': { [COLD_WATER]: 1 },
           },
           type: 'ElbowTube',
         },
         {
           flows: {
-            "4.5,2": { [COLD_WATER]: -1 },
-            "4.5,3": { [COLD_WATER]: -1 },
-            "5,2.5": { [COLD_WATER]: 2 },
+            '4.5,2': { [COLD_WATER]: -1 },
+            '4.5,3': { [COLD_WATER]: -1 },
+            '5,2.5': { [COLD_WATER]: 2 },
           },
           type: 'TeeTube',
         },
         {
           flows: {
-            "-1,-1": { [COLD_WATER]: 2 },
-            "5,2.5": { [COLD_WATER]: -2 },
+            '-1,-1': { [COLD_WATER]: 2 },
+            '5,2.5': { [COLD_WATER]: -2 },
           },
           type: 'SystemIO',
         },
@@ -756,10 +752,10 @@ describe('Two sources joining', () => {
       [
         {
           'flows': {
-            "-1,-1": {
+            '-1,-1': {
               [COLD_WATER]: -2,
             },
-            "2,1.5": {
+            '2,1.5': {
               [COLD_WATER]: 2,
             },
           },
@@ -769,10 +765,10 @@ describe('Two sources joining', () => {
         },
         {
           'flows': {
-            "-1,-1": {
+            '-1,-1': {
               [HOT_WATER]: -2,
             },
-            "2,3.5": {
+            '2,3.5': {
               [HOT_WATER]: 2,
             },
           },
@@ -782,10 +778,10 @@ describe('Two sources joining', () => {
         },
         {
           flows: {
-            "2,1.5": {
+            '2,1.5': {
               [COLD_WATER]: -2,
             },
-            "2.5,2": {
+            '2.5,2': {
               [COLD_WATER]: 2,
             },
           },
@@ -795,10 +791,10 @@ describe('Two sources joining', () => {
         },
         {
           'flows': {
-            "2,3.5": {
+            '2,3.5': {
               [HOT_WATER]: -2,
             },
-            "2.5,3": {
+            '2.5,3': {
               [HOT_WATER]: 2,
             },
           },
@@ -808,13 +804,13 @@ describe('Two sources joining', () => {
         },
         {
           'flows': {
-            "2.5,2": {
+            '2.5,2': {
               [COLD_WATER]: -2,
             },
-            "2.5,3": {
+            '2.5,3': {
               [HOT_WATER]: -2,
             },
-            "3,2.5": {
+            '3,2.5': {
               [COLD_WATER]: 2,
               [HOT_WATER]: 2,
             },
@@ -825,11 +821,11 @@ describe('Two sources joining', () => {
         },
         {
           'flows': {
-            "-1,-1": {
+            '-1,-1': {
               [COLD_WATER]: 2,
               [HOT_WATER]: 2,
             },
-            "3,2.5": {
+            '3,2.5': {
               [COLD_WATER]: -2,
               [HOT_WATER]: -2,
             },
@@ -850,7 +846,7 @@ describe('A path with a bridge', () => {
     {
       x: 11,
       y: 2,
-      type: "SystemIO",
+      type: 'SystemIO',
       rotate: 0,
       settings: {
         liquids: [COLD_WATER],
@@ -860,19 +856,19 @@ describe('A path with a bridge', () => {
     {
       x: 12,
       y: 2,
-      type: "StraightTube",
+      type: 'StraightTube',
       rotate: 0,
       settings: {},
     },
     {
-      type: "BridgeTube",
+      type: 'BridgeTube',
       x: 13,
       y: 2,
       rotate: 0,
       settings: {},
     },
     {
-      type: "SystemIO",
+      type: 'SystemIO',
       x: 13,
       y: 1,
       rotate: 90,
@@ -881,12 +877,12 @@ describe('A path with a bridge', () => {
     {
       x: 14,
       y: 2,
-      type: "ElbowTube",
+      type: 'ElbowTube',
       rotate: 180,
       settings: {},
     },
     {
-      type: "ElbowTube",
+      type: 'ElbowTube',
       x: 14,
       y: 3,
       rotate: 270,
@@ -895,7 +891,7 @@ describe('A path with a bridge', () => {
     {
       x: 13,
       y: 3,
-      type: "ElbowTube",
+      type: 'ElbowTube',
       rotate: 0,
       settings: {},
     },
@@ -908,17 +904,17 @@ describe('A path with a bridge', () => {
         {
           x: 11,
           y: 2,
-          type: "SystemIO",
+          type: 'SystemIO',
           rotate: 0,
           settings: {
             liquids: [COLD_WATER],
             pressure: 8,
           },
           flows: {
-            "-1,-1": {
+            '-1,-1': {
               [COLD_WATER]: -1,
             },
-            "12,2.5": {
+            '12,2.5': {
               [COLD_WATER]: 1,
             },
           },
@@ -926,50 +922,50 @@ describe('A path with a bridge', () => {
         {
           x: 12,
           y: 2,
-          type: "StraightTube",
+          type: 'StraightTube',
           rotate: 0,
           settings: {},
           flows: {
-            "12,2.5": {
+            '12,2.5': {
               [COLD_WATER]: -1,
             },
-            "13,2.5": {
+            '13,2.5': {
               [COLD_WATER]: 1,
             },
           },
         },
         {
-          type: "BridgeTube",
+          type: 'BridgeTube',
           x: 13,
           y: 2,
           rotate: 0,
           settings: {},
           flows: {
-            "13.5,3": {
+            '13.5,3': {
               [COLD_WATER]: -1,
             },
-            "13.5,2": {
+            '13.5,2': {
               [COLD_WATER]: 1,
             },
-            "14,2.5": {
+            '14,2.5': {
               [COLD_WATER]: 1,
             },
-            "13,2.5": {
+            '13,2.5': {
               [COLD_WATER]: -1,
             },
           },
         },
         {
-          type: "SystemIO",
+          type: 'SystemIO',
           x: 13,
           y: 1,
           rotate: 90,
           settings: {},
           flows: {
-            "13.5,2": {
+            '13.5,2': {
               [COLD_WATER]: -1,
             },
-            "-1,-1": {
+            '-1,-1': {
               [COLD_WATER]: 1,
             },
           },
@@ -977,29 +973,29 @@ describe('A path with a bridge', () => {
         {
           x: 14,
           y: 2,
-          type: "ElbowTube",
+          type: 'ElbowTube',
           rotate: 180,
           settings: {},
           flows: {
-            "14,2.5": {
+            '14,2.5': {
               [COLD_WATER]: -1,
             },
-            "14.5,3": {
+            '14.5,3': {
               [COLD_WATER]: 1,
             },
           },
         },
         {
-          type: "ElbowTube",
+          type: 'ElbowTube',
           x: 14,
           y: 3,
           rotate: 270,
           settings: {},
           flows: {
-            "14.5,3": {
+            '14.5,3': {
               [COLD_WATER]: -1,
             },
-            "14,3.5": {
+            '14,3.5': {
               [COLD_WATER]: 1,
             },
           },
@@ -1007,14 +1003,14 @@ describe('A path with a bridge', () => {
         {
           x: 13,
           y: 3,
-          type: "ElbowTube",
+          type: 'ElbowTube',
           rotate: 0,
           settings: {},
           flows: {
-            "14,3.5": {
+            '14,3.5': {
               [COLD_WATER]: -1,
             },
-            "13.5,3": {
+            '13.5,3': {
               [COLD_WATER]: 1,
             },
           },

--- a/tests/unit/calculateFlows.test.ts
+++ b/tests/unit/calculateFlows.test.ts
@@ -31,6 +31,7 @@ const propertyWalker = (acc: any[], next: FlowSegment, prop: string[]): any[] =>
 
 describe('Data describing an input tube', () => {
   const part: PersistentPart = {
+    id: '',
     x: 1,
     y: 2,
     rotate: 0,
@@ -54,6 +55,7 @@ describe('Data describing an input tube', () => {
 describe('asFlowParts', () => {
   const path: PersistentPart[] = [
     {
+      id: 'one',
       x: 1,
       y: 2,
       rotate: 0,
@@ -63,6 +65,7 @@ describe('asFlowParts', () => {
       },
     },
     {
+      id: 'two',
       x: 2,
       y: 2,
       rotate: 0,
@@ -70,6 +73,7 @@ describe('asFlowParts', () => {
       settings: {},
     },
     {
+      id: 'three',
       x: 3,
       y: 2,
       rotate: 0,
@@ -89,6 +93,7 @@ describe('asFlowParts', () => {
 describe('A single path without splits', () => {
   const parts: PersistentPart[] = [
     {
+      id: '1',
       x: 1,
       y: 2,
       rotate: 0,
@@ -99,6 +104,7 @@ describe('A single path without splits', () => {
       },
     },
     {
+      id: '2',
       x: 3,
       y: 2,
       rotate: 180,
@@ -106,6 +112,7 @@ describe('A single path without splits', () => {
       settings: {},
     },
     {
+      id: '3',
       x: 2,
       y: 2,
       rotate: 0,
@@ -197,6 +204,7 @@ describe('A single path without splits', () => {
 describe('A path with a split, but no joins', () => {
   const parts: PersistentPart[] = [
     {
+      id: '1',
       x: 1,
       y: 2,
       rotate: 0,
@@ -207,6 +215,7 @@ describe('A path with a split, but no joins', () => {
       },
     },
     {
+      id: '2',
       x: 2,
       y: 2,
       rotate: 0,
@@ -214,6 +223,7 @@ describe('A path with a split, but no joins', () => {
       settings: {},
     },
     {
+      id: '3',
       x: 3,
       y: 2,
       rotate: 270,
@@ -221,6 +231,7 @@ describe('A path with a split, but no joins', () => {
       settings: {},
     },
     {
+      id: '4',
       x: 3,
       y: 1,
       rotate: 90,
@@ -228,6 +239,7 @@ describe('A path with a split, but no joins', () => {
       settings: {},
     },
     {
+      id: '5',
       x: 3,
       y: 3,
       rotate: 270,
@@ -365,6 +377,7 @@ describe('A path with a split, but no joins', () => {
 describe('A path that forks and rejoins', () => {
   const parts: PersistentPart[] = [
     {
+      id: '1',
       x: 1,
       y: 2,
       rotate: 0,
@@ -375,6 +388,7 @@ describe('A path that forks and rejoins', () => {
       },
     },
     {
+      id: '2',
       x: 2,
       y: 2,
       rotate: 0,
@@ -382,6 +396,7 @@ describe('A path that forks and rejoins', () => {
       settings: {},
     },
     {
+      id: '3',
       x: 3,
       y: 2,
       rotate: 270,
@@ -389,6 +404,7 @@ describe('A path that forks and rejoins', () => {
       settings: {},
     },
     {
+      id: '4',
       x: 3,
       y: 1,
       rotate: 90,
@@ -396,6 +412,7 @@ describe('A path that forks and rejoins', () => {
       settings: {},
     },
     {
+      id: '5',
       x: 3,
       y: 3,
       rotate: 0,
@@ -403,6 +420,7 @@ describe('A path that forks and rejoins', () => {
       settings: {},
     },
     {
+      id: '6',
       x: 4,
       y: 1,
       rotate: 180,
@@ -410,6 +428,7 @@ describe('A path that forks and rejoins', () => {
       settings: {},
     },
     {
+      id: '7',
       x: 4,
       y: 3,
       rotate: 270,
@@ -417,6 +436,7 @@ describe('A path that forks and rejoins', () => {
       settings: {},
     },
     {
+      id: '8',
       x: 4,
       y: 2,
       rotate: 90,
@@ -424,6 +444,7 @@ describe('A path that forks and rejoins', () => {
       settings: {},
     },
     {
+      id: '9',
       x: 5,
       y: 2,
       rotate: 180,
@@ -568,6 +589,7 @@ describe('A path that forks and rejoins', () => {
 describe('A single path with a pump', () => {
   const parts: PersistentPart[] = [
     {
+      id: '1',
       x: 3,
       y: 2,
       rotate: 180,
@@ -578,6 +600,7 @@ describe('A single path with a pump', () => {
       },
     },
     {
+      id: '2',
       x: 2,
       y: 2,
       rotate: 0,
@@ -588,6 +611,7 @@ describe('A single path with a pump', () => {
       },
     },
     {
+      id: '3',
       x: 1,
       y: 2,
       rotate: 0,
@@ -602,6 +626,7 @@ describe('A single path with a pump', () => {
     const partsWithFlow = calculateFlows(flowParts);
     expect(partsWithFlow).toMatchObject(
       [{
+        id: '1',
         x: 3,
         y: 2,
         rotate: 180,
@@ -616,6 +641,7 @@ describe('A single path with a pump', () => {
         },
       },
       {
+        id: '2',
         x: 2,
         y: 2,
         rotate: 0,
@@ -630,6 +656,7 @@ describe('A single path with a pump', () => {
         },
       },
       {
+        id: '3',
         x: 1,
         y: 2,
         rotate: 0,
@@ -651,6 +678,7 @@ describe('A single path with a pump', () => {
       const partsWithFlow = calculateFlows(flowParts);
       expect(partsWithFlow).toMatchObject(
         [{
+          id: '1',
           x: 3,
           y: 2,
           rotate: 180,
@@ -664,6 +692,7 @@ describe('A single path with a pump', () => {
           },
         },
         {
+          id: '2',
           x: 2,
           y: 2,
           rotate: 0,
@@ -678,6 +707,7 @@ describe('A single path with a pump', () => {
           },
         },
         {
+          id: '3',
           x: 1,
           y: 2,
           rotate: 0,
@@ -697,6 +727,7 @@ describe('A single path with a pump', () => {
 describe('Two sources joining', () => {
   const parts: PersistentPart[] = [
     {
+      id: '1',
       x: 1,
       y: 1,
       rotate: 0,
@@ -707,6 +738,7 @@ describe('Two sources joining', () => {
       },
     },
     {
+      id: '2',
       x: 1,
       y: 3,
       rotate: 0,
@@ -717,6 +749,7 @@ describe('Two sources joining', () => {
       },
     },
     {
+      id: '3',
       x: 2,
       y: 1,
       rotate: 180,
@@ -724,6 +757,7 @@ describe('Two sources joining', () => {
       settings: {},
     },
     {
+      id: '4',
       x: 2,
       y: 3,
       rotate: 270,
@@ -731,6 +765,7 @@ describe('Two sources joining', () => {
       settings: {},
     },
     {
+      id: '5',
       x: 2,
       y: 2,
       rotate: 90,
@@ -738,6 +773,7 @@ describe('Two sources joining', () => {
       settings: {},
     },
     {
+      id: '6',
       x: 3,
       y: 2,
       rotate: 180,
@@ -844,6 +880,7 @@ describe('Two sources joining', () => {
 describe('A path with a bridge', () => {
   const parts: PersistentPart[] = [
     {
+      id: '1',
       x: 11,
       y: 2,
       type: 'SystemIO',
@@ -854,6 +891,7 @@ describe('A path with a bridge', () => {
       },
     },
     {
+      id: '2',
       x: 12,
       y: 2,
       type: 'StraightTube',
@@ -861,6 +899,7 @@ describe('A path with a bridge', () => {
       settings: {},
     },
     {
+      id: '3',
       type: 'BridgeTube',
       x: 13,
       y: 2,
@@ -868,6 +907,7 @@ describe('A path with a bridge', () => {
       settings: {},
     },
     {
+      id: '4',
       type: 'SystemIO',
       x: 13,
       y: 1,
@@ -875,6 +915,7 @@ describe('A path with a bridge', () => {
       settings: {},
     },
     {
+      id: '5',
       x: 14,
       y: 2,
       type: 'ElbowTube',
@@ -882,6 +923,7 @@ describe('A path with a bridge', () => {
       settings: {},
     },
     {
+      id: '6',
       type: 'ElbowTube',
       x: 14,
       y: 3,
@@ -889,6 +931,7 @@ describe('A path with a bridge', () => {
       settings: {},
     },
     {
+      id: '7',
       x: 13,
       y: 3,
       type: 'ElbowTube',


### PR DESCRIPTION
Add dropdown menu with tool selector.

Tools can modify click and drag behavior in the process view widget. Available tools:

- New
- Move
- Rotate
- Edit Settings
- Copy
- Delete

Widgets no longer support long press to open configuration.
An UID was added to all parts. Parts are now considered same when the ID matches, not when they have the same placement / type.