### PR TITLE
Avoid datastore conflicts in Process View

### DIFF
--- a/src/pages/DashboardPage.vue
+++ b/src/pages/DashboardPage.vue
@@ -140,16 +140,16 @@ export default class DashboardPage extends Vue {
     }
   }
 
-  onChangeSize(id: string, cols: number, rows: number) {
-    updateDashboardItemSize(this.$store, { id, cols, rows });
+  async onChangeSize(id: string, cols: number, rows: number) {
+    await updateDashboardItemSize(this.$store, { id, cols, rows });
   }
 
-  onChangeItemConfig(id: string, config: any) {
-    updateDashboardItemConfig(this.$store, { id, config });
+  async onChangeItemConfig(id: string, config: any) {
+    await updateDashboardItemConfig(this.$store, { id, config });
   }
 
-  onChangeItemTitle(id: string, title: string) {
-    saveDashboardItem(this.$store, { ...dashboardItemById(this.$store, id), title });
+  async onChangeItemTitle(id: string, title: string) {
+    await saveDashboardItem(this.$store, { ...dashboardItemById(this.$store, id), title });
   }
 
   onDeleteItem(itemId: string) {

--- a/src/plugins/spark/features/ProcessView/calculateFlows.ts
+++ b/src/plugins/spark/features/ProcessView/calculateFlows.ts
@@ -1,5 +1,5 @@
 import {
-  PersistentPart,
+  StatePart,
   Transitions,
   FlowPart,
   CalculatedFlows,
@@ -23,16 +23,16 @@ export const removeTransitions =
     part => ({ ...part, transitions: omit(part.transitions, inCoord) }));
 
 export const partSettings =
-  (part: PersistentPart): ComponentSettings => settings[part.type];
+  (part: StatePart): ComponentSettings => settings[part.type];
 
 export const partTransitions =
-  (part: PersistentPart): Transitions => partSettings(part).transitions(part);
+  (part: StatePart): Transitions => partSettings(part).transitions(part);
 
 export const partSize =
-  (part: PersistentPart): [number, number] => partSettings(part).size(part);
+  (part: StatePart): [number, number] => partSettings(part).size(part);
 
 export const partCenter =
-  (part: PersistentPart): [number, number] => {
+  (part: StatePart): [number, number] => {
     const [sizeX, sizeY] = partSize(part);
     return [0.5 * sizeX, 0.5 * sizeY];
   };
@@ -64,7 +64,7 @@ const normalizeFlows = (part: FlowPart): FlowPart => {
 };
 
 
-const translations = (part: PersistentPart): Transitions =>
+const translations = (part: StatePart): Transitions =>
   Object.entries(partTransitions(part))
     .reduce((acc, [inCoords, transition]: [string, any]) => {
       const unrotatedAnchor = new Coordinates(part)
@@ -86,7 +86,7 @@ const translations = (part: PersistentPart): Transitions =>
       {},
     );
 
-export const asFlowParts = (parts: PersistentPart[]): FlowPart[] =>
+export const asFlowParts = (parts: StatePart[]): FlowPart[] =>
   parts.map(part => ({ ...part, transitions: translations(part), flows: {} }));
 
 const combineFlows =
@@ -422,5 +422,5 @@ const unbalancedFlow = (part: FlowPart): number =>
       0);
 
 
-export const calculateNormalizedFlows = (parts: PersistentPart[]): FlowPart[] =>
+export const calculateNormalizedFlows = (parts: StatePart[]): FlowPart[] =>
   calculateFlows(asFlowParts(parts)).map(normalizeFlows);

--- a/src/plugins/spark/features/ProcessView/components/PartCard.ts
+++ b/src/plugins/spark/features/ProcessView/components/PartCard.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
-import { FlowPart, PersistentPart } from '../state';
+import { FlowPart } from '../state';
 
 @Component({
   props: {

--- a/src/plugins/spark/features/ProcessView/components/PartCard.ts
+++ b/src/plugins/spark/features/ProcessView/components/PartCard.ts
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
-import { FlowPart } from '../state';
+import { FlowPart, PersistentPart } from '../state';
 
 @Component({
   props: {
@@ -16,7 +16,11 @@ export default class PartCard extends Vue {
   }
 
   protected savePart(part: FlowPart = this.part): void {
-    this.$emit('input', { ...part });
+    this.$emit('input', part);
+  }
+
+  protected savePartState(part: FlowPart = this.part): void {
+    this.$emit('state', part);
   }
 
   protected removePart(): void {

--- a/src/plugins/spark/features/ProcessView/components/PartComponent.ts
+++ b/src/plugins/spark/features/ProcessView/components/PartComponent.ts
@@ -36,6 +36,14 @@ export default class PartComponent extends Vue {
     return this.part.flows;
   }
 
+  protected get settings(): Record<string, any> {
+    return this.part.settings || {};
+  }
+
+  protected get state(): Record<string, any> {
+    return this.part.state || {};
+  }
+
   protected get size(): [number, number] {
     return partSettings[this.part.type].size(this.part);
   }
@@ -69,7 +77,11 @@ export default class PartComponent extends Vue {
       .reduce((sum, v) => sum + v, 0);
   }
 
-  protected settings(): Record<string, any> {
-    return this.part.settings || {};
+  protected savePart(part: FlowPart = this.part): void {
+    this.$emit('input', part);
+  }
+
+  protected savePartState(part: FlowPart = this.part): void {
+    this.$emit('state', part);
   }
 }

--- a/src/plugins/spark/features/ProcessView/components/PartComponent.ts
+++ b/src/plugins/spark/features/ProcessView/components/PartComponent.ts
@@ -29,22 +29,33 @@ export default class PartComponent extends Vue {
   }
 
   protected toggleFlipped(): void {
-    this.$parent.$emit('input', { ...this.part, flipped: !this.flipped });
+    this.$emit('input', { ...this.part, flipped: !this.flipped });
   }
 
   protected get flow(): CalculatedFlows {
     return this.part.flows;
   }
 
+  protected get size(): [number, number] {
+    return partSettings[this.part.type].size(this.part);
+  }
+
+  protected get sizeX(): number {
+    return this.size[0];
+  }
+
+  protected get sizeY(): number {
+    return this.size[1];
+  }
+
   private rotatedCoord(coord: string): string {
-    const [sizeX, sizeY] = partSettings[this.part.type].size(this.part);
-    if (sizeX === 1 && sizeY === 1) {
+    if (this.sizeX === 1 && this.sizeY === 1) {
       return coord;
     }
     const anchor = new Coordinates([0, 0])
-      .rotateSquare(-this.part.rotate, this.part.rotate, [sizeX, sizeY]);
+      .rotateSquare(-this.part.rotate, this.part.rotate, [this.sizeX, this.sizeY]);
     return new Coordinates(coord)
-      .rotate(this.part.rotate, [0.5 * sizeX, 0.5 * sizeY])
+      .rotate(this.part.rotate, [0.5 * this.sizeX, 0.5 * this.sizeY])
       .translate(anchor)
       .toString();
   }

--- a/src/plugins/spark/features/ProcessView/components/ProcessViewItem.vue
+++ b/src/plugins/spark/features/ProcessView/components/ProcessViewItem.vue
@@ -20,7 +20,13 @@ export default class ProcessViewItem extends Vue {
 
 <template>
   <g :transform="transformation">
-    <component v-if="value.type" :value="value" :is="value.type" class="ProcessViewPart"/>
+    <component
+      v-if="value.type"
+      :value="value"
+      :is="value.type"
+      class="ProcessViewPart"
+      v-on="$listeners"
+    />
   </g>
 </template>
 

--- a/src/plugins/spark/features/ProcessView/parts/ActuatorValve.vue
+++ b/src/plugins/spark/features/ProcessView/parts/ActuatorValve.vue
@@ -65,7 +65,7 @@ export default class ActuatorValve extends PartComponent {
   }
 
   get closed() {
-    return Boolean(this.part.settings.closed);
+    return Boolean(this.state.closed);
   }
 
   get valveRotation() {
@@ -88,8 +88,9 @@ export default class ActuatorValve extends PartComponent {
       ? this.actuatorBlock.data.state !== 1
       : true;
 
-    if (closed !== this.part.settings.closed) {
-      this.$emit('input', { ...this.part, settings: { ...this.part.settings, closed } });
+    if (closed !== this.part.state.closed) {
+      this.state.closed = closed;
+      this.savePartState();
     }
   }
 

--- a/src/plugins/spark/features/ProcessView/parts/ActuatorValve.vue
+++ b/src/plugins/spark/features/ProcessView/parts/ActuatorValve.vue
@@ -89,7 +89,7 @@ export default class ActuatorValve extends PartComponent {
       : true;
 
     if (closed !== this.part.settings.closed) {
-      this.$parent.$emit('input', { ...this.part, settings: { ...this.part.settings, closed } });
+      this.$emit('input', { ...this.part, settings: { ...this.part.settings, closed } });
     }
   }
 
@@ -110,6 +110,8 @@ export default class ActuatorValve extends PartComponent {
 
 <template>
   <g class="actuator-valve clickable" @click="toggleClosed">
+    <!-- background element, to make the full square clickable -->
+    <rect :width="sizeX*SQUARE_SIZE" :height="sizeY*SQUARE_SIZE" fill="black" opacity="0"/>
     <foreignObject v-if="!actuatorBlock" :height="SQUARE_SIZE" :width="SQUARE_SIZE">
       <q-icon name="mdi-link-variant-off" size="sm" class="absolute-right" style="height: 15px;"/>
     </foreignObject>

--- a/src/plugins/spark/features/ProcessView/parts/Kettle.vue
+++ b/src/plugins/spark/features/ProcessView/parts/Kettle.vue
@@ -14,8 +14,8 @@ export default class Kettle extends PartComponent {
     </g>
     <g class="outline">
       <rect
-        :width="SQUARE_SIZE*4-4"
-        :height="SQUARE_SIZE*6-4"
+        :width="SQUARE_SIZE*sizeX-4"
+        :height="SQUARE_SIZE*sizeY-4"
         x="2"
         y="2"
         rx="8"

--- a/src/plugins/spark/features/ProcessView/parts/LargeKettle.vue
+++ b/src/plugins/spark/features/ProcessView/parts/LargeKettle.vue
@@ -14,8 +14,8 @@ export default class LargeKettle extends PartComponent {
     </g>
     <g class="outline">
       <rect
-        :width="SQUARE_SIZE*6-4"
-        :height="SQUARE_SIZE*8-4"
+        :width="SQUARE_SIZE*sizeX-4"
+        :height="SQUARE_SIZE*sizeY-4"
         x="2"
         y="2"
         rx="8"

--- a/src/plugins/spark/features/ProcessView/parts/Pump.vue
+++ b/src/plugins/spark/features/ProcessView/parts/Pump.vue
@@ -11,7 +11,7 @@ export default class Pump extends PartComponent {
   }
 
   protected toggleDisabled(): void {
-    this.$parent.$emit('input', { ...this.part, settings: { ...this.part.settings, disabled: !this.disabled } });
+    this.$emit('input', { ...this.part, settings: { ...this.part.settings, disabled: !this.disabled } });
   }
 
   get liquids() {
@@ -22,6 +22,8 @@ export default class Pump extends PartComponent {
 
 <template>
   <g class="pump clickable" @click="toggleDisabled">
+    <!-- background element, to make the full square clickable -->
+    <rect :width="sizeX*SQUARE_SIZE" :height="sizeY*SQUARE_SIZE" fill="black" opacity="0"/>
     <!-- tube liquid bottom-->
     <LiquidStroke :paths="['M50,25H0']" :colors="liquids"/>
     <!-- ball liquid -->

--- a/src/plugins/spark/features/ProcessView/parts/SmallKettle.vue
+++ b/src/plugins/spark/features/ProcessView/parts/SmallKettle.vue
@@ -14,8 +14,8 @@ export default class SmallKettle extends PartComponent {
     </g>
     <g class="outline">
       <rect
-        :width="SQUARE_SIZE*2-4"
-        :height="SQUARE_SIZE*2-4"
+        :width="SQUARE_SIZE*sizeX-4"
+        :height="SQUARE_SIZE*sizeY-4"
         x="2"
         y="2"
         rx="8"

--- a/src/plugins/spark/features/ProcessView/parts/Valve.vue
+++ b/src/plugins/spark/features/ProcessView/parts/Valve.vue
@@ -40,7 +40,8 @@ export default class Valve extends PartComponent {
   }
 
   protected toggleClosed(): void {
-    this.$emit('input', { ...this.part, settings: { ...this.part.settings, closed: !this.closed } });
+    this.part.settings.closed = !this.closed;
+    this.savePart();
   }
 }
 </script>

--- a/src/plugins/spark/features/ProcessView/parts/Valve.vue
+++ b/src/plugins/spark/features/ProcessView/parts/Valve.vue
@@ -40,13 +40,15 @@ export default class Valve extends PartComponent {
   }
 
   protected toggleClosed(): void {
-    this.$parent.$emit('input', { ...this.part, settings: { ...this.part.settings, closed: !this.closed } });
+    this.$emit('input', { ...this.part, settings: { ...this.part.settings, closed: !this.closed } });
   }
 }
 </script>
 
 <template>
   <g class="valve clickable" @click="toggleClosed">
+    <!-- background element, to make the full square clickable -->
+    <rect :width="sizeX*SQUARE_SIZE" :height="sizeY*SQUARE_SIZE" fill="black" opacity="0"/>
     <g key="valve-outer" class="outline">
       <path :d="paths.outerValve[0]"/>
       <path :d="paths.outerValve[1]"/>

--- a/src/plugins/spark/features/ProcessView/parts/WhirlpoolInlet.vue
+++ b/src/plugins/spark/features/ProcessView/parts/WhirlpoolInlet.vue
@@ -27,12 +27,12 @@ export default class WhirlpoolInlet extends PartComponent {
 
 <template>
   <g class="whirlpool-inlet">
+    <LiquidStroke :paths="[paths.liquid]" :colors="liquids"/>
     <g class="outline">
       <rect y="12" width="8" height="8" fill="white"/>
       <rect y="30" width="8" height="8" fill="white"/>
       <path v-for="border in paths.borders" :key="border" :d="border"/>
     </g>
-    <LiquidStroke :paths="[paths.liquid]" :colors="liquids"/>
     <AnimatedArrows :speed="flowSpeed" :path="paths.liquid" :num-arrows="8"/>
   </g>
 </template>

--- a/src/plugins/spark/features/ProcessView/settings/ActuatorValve.ts
+++ b/src/plugins/spark/features/ProcessView/settings/ActuatorValve.ts
@@ -1,12 +1,12 @@
-import { ComponentSettings, PersistentPart, Transitions } from '../state';
+import { ComponentSettings, Transitions, StatePart } from '../state';
 import { LEFT, RIGHT } from '../getters';
 import { defaultSettings } from '../components/getters';
 
 const settings: ComponentSettings = {
   ...defaultSettings,
   cards: ['ActuatorPartCard'],
-  transitions: (part: PersistentPart): Transitions =>
-    ((part.settings || {}).closed)
+  transitions: (part: StatePart): Transitions =>
+    ((part.state || {}).closed)
       ? {}
       : {
         [LEFT]: [{ outCoords: RIGHT }],

--- a/src/plugins/spark/features/ProcessView/settings/Pump.ts
+++ b/src/plugins/spark/features/ProcessView/settings/Pump.ts
@@ -1,10 +1,10 @@
-import { ComponentSettings, PersistentPart } from '../state';
+import { ComponentSettings, StatePart } from '../state';
 import { LEFT, RIGHT, DEFAULT_PUMP_PRESSURE, ACCELERATE_OTHERS } from '../getters';
 import { defaultSettings } from '../components/getters';
 
 const settings: ComponentSettings = {
   ...defaultSettings,
-  transitions: (part: PersistentPart) => {
+  transitions: (part: StatePart) => {
     const p = (part.settings || {}).disabled ? 0 : part.settings.pressure || DEFAULT_PUMP_PRESSURE;
     return {
       [LEFT]: [{ outCoords: RIGHT }],

--- a/src/plugins/spark/features/ProcessView/settings/Valve.ts
+++ b/src/plugins/spark/features/ProcessView/settings/Valve.ts
@@ -1,10 +1,10 @@
-import { ComponentSettings, PersistentPart, Transitions } from '../state';
+import { ComponentSettings, Transitions, StatePart } from '../state';
 import { LEFT, RIGHT } from '../getters';
 import { defaultSettings } from '../components/getters';
 
 const settings: ComponentSettings = {
   ...defaultSettings,
-  transitions: (part: PersistentPart): Transitions =>
+  transitions: (part: StatePart): Transitions =>
     ((part.settings || {}).closed)
       ? {}
       : {

--- a/src/plugins/spark/features/ProcessView/state.d.ts
+++ b/src/plugins/spark/features/ProcessView/state.d.ts
@@ -29,16 +29,20 @@ export interface PersistentPart {
   settings: Record<string, any>;
 }
 
-export interface ComponentSettings {
-  cards: string[];
-  transitions: (part: PersistentPart) => Transitions;
-  size: (part: PersistentPart) => [number, number];
-  blockedCoordinates: (part: PersistentPart) => Coordinates[];
+export interface StatePart extends PersistentPart {
+  state: Record<string, any>;
 }
 
-export interface FlowPart extends PersistentPart {
+export interface FlowPart extends StatePart {
   transitions: Transitions;
   flows: CalculatedFlows;
+}
+
+export interface ComponentSettings {
+  cards: string[];
+  transitions: (part: StatePart) => Transitions;
+  size: (part: PersistentPart) => [number, number];
+  blockedCoordinates: (part: PersistentPart) => Coordinates[];
 }
 
 export interface ProcessViewConfig {

--- a/tests/unit/calculateFlows.test.ts
+++ b/tests/unit/calculateFlows.test.ts
@@ -5,7 +5,7 @@ import {
   FlowSegment,
   calculateFlows,
 } from '@/plugins/spark/features/ProcessView/calculateFlows';
-import { PersistentPart } from '@/plugins/spark/features/ProcessView/state';
+import { StatePart } from '@/plugins/spark/features/ProcessView/state';
 import { IN_OUT, COLD_WATER, HOT_WATER } from '@/plugins/spark/features/ProcessView/getters';
 import get from 'lodash/get';
 import set from 'lodash/set';
@@ -30,7 +30,7 @@ const propertyWalker = (acc: any[], next: FlowSegment, prop: string[]): any[] =>
 };
 
 describe('Data describing an input tube', () => {
-  const part: PersistentPart = {
+  const part: StatePart = {
     id: '',
     x: 1,
     y: 2,
@@ -40,6 +40,7 @@ describe('Data describing an input tube', () => {
       pressure: 11,
       liquids: [COLD_WATER],
     },
+    state: {},
   };
 
   it('can resolve to transitions', () => {
@@ -53,7 +54,7 @@ describe('Data describing an input tube', () => {
 
 
 describe('asFlowParts', () => {
-  const path: PersistentPart[] = [
+  const path: StatePart[] = [
     {
       id: 'one',
       x: 1,
@@ -63,6 +64,7 @@ describe('asFlowParts', () => {
       settings: {
         liquids: [COLD_WATER],
       },
+      state: {},
     },
     {
       id: 'two',
@@ -71,6 +73,7 @@ describe('asFlowParts', () => {
       rotate: 0,
       type: 'StraightTube',
       settings: {},
+      state: {},
     },
     {
       id: 'three',
@@ -79,6 +82,7 @@ describe('asFlowParts', () => {
       rotate: 0,
       type: 'SystemIO',
       settings: {},
+      state: {},
     },
   ];
 
@@ -91,7 +95,7 @@ describe('asFlowParts', () => {
 
 
 describe('A single path without splits', () => {
-  const parts: PersistentPart[] = [
+  const parts: StatePart[] = [
     {
       id: '1',
       x: 1,
@@ -102,6 +106,7 @@ describe('A single path without splits', () => {
         pressure: 6,
         liquids: [HOT_WATER],
       },
+      state: {},
     },
     {
       id: '2',
@@ -110,6 +115,7 @@ describe('A single path without splits', () => {
       rotate: 180,
       type: 'SystemIO',
       settings: {},
+      state: {},
     },
     {
       id: '3',
@@ -118,6 +124,7 @@ describe('A single path without splits', () => {
       rotate: 0,
       type: 'StraightTube',
       settings: {},
+      state: {},
     },
   ];
 
@@ -202,7 +209,7 @@ describe('A single path without splits', () => {
 
 
 describe('A path with a split, but no joins', () => {
-  const parts: PersistentPart[] = [
+  const parts: StatePart[] = [
     {
       id: '1',
       x: 1,
@@ -213,6 +220,7 @@ describe('A path with a split, but no joins', () => {
         pressure: 14,
         liquids: [COLD_WATER],
       },
+      state: {},
     },
     {
       id: '2',
@@ -221,6 +229,7 @@ describe('A path with a split, but no joins', () => {
       rotate: 0,
       type: 'StraightTube',
       settings: {},
+      state: {},
     },
     {
       id: '3',
@@ -229,6 +238,7 @@ describe('A path with a split, but no joins', () => {
       rotate: 270,
       type: 'TeeTube',
       settings: {},
+      state: {},
     },
     {
       id: '4',
@@ -237,6 +247,7 @@ describe('A path with a split, but no joins', () => {
       rotate: 90,
       type: 'SystemIO',
       settings: {},
+      state: {},
     },
     {
       id: '5',
@@ -245,6 +256,7 @@ describe('A path with a split, but no joins', () => {
       rotate: 270,
       type: 'SystemIO',
       settings: {},
+      state: {},
     },
   ];
 
@@ -375,7 +387,7 @@ describe('A path with a split, but no joins', () => {
 });
 
 describe('A path that forks and rejoins', () => {
-  const parts: PersistentPart[] = [
+  const parts: StatePart[] = [
     {
       id: '1',
       x: 1,
@@ -386,6 +398,7 @@ describe('A path that forks and rejoins', () => {
         pressure: 11,
         liquids: [COLD_WATER],
       },
+      state: {},
     },
     {
       id: '2',
@@ -394,6 +407,7 @@ describe('A path that forks and rejoins', () => {
       rotate: 0,
       type: 'StraightTube',
       settings: {},
+      state: {},
     },
     {
       id: '3',
@@ -402,6 +416,7 @@ describe('A path that forks and rejoins', () => {
       rotate: 270,
       type: 'TeeTube',
       settings: {},
+      state: {},
     },
     {
       id: '4',
@@ -410,6 +425,7 @@ describe('A path that forks and rejoins', () => {
       rotate: 90,
       type: 'ElbowTube',
       settings: {},
+      state: {},
     },
     {
       id: '5',
@@ -418,6 +434,7 @@ describe('A path that forks and rejoins', () => {
       rotate: 0,
       type: 'ElbowTube',
       settings: {},
+      state: {},
     },
     {
       id: '6',
@@ -426,6 +443,7 @@ describe('A path that forks and rejoins', () => {
       rotate: 180,
       type: 'ElbowTube',
       settings: {},
+      state: {},
     },
     {
       id: '7',
@@ -434,6 +452,7 @@ describe('A path that forks and rejoins', () => {
       rotate: 270,
       type: 'ElbowTube',
       settings: {},
+      state: {},
     },
     {
       id: '8',
@@ -442,6 +461,7 @@ describe('A path that forks and rejoins', () => {
       rotate: 90,
       type: 'TeeTube',
       settings: {},
+      state: {},
     },
     {
       id: '9',
@@ -450,6 +470,7 @@ describe('A path that forks and rejoins', () => {
       rotate: 180,
       type: 'SystemIO',
       settings: {},
+      state: {},
     },
   ];
 
@@ -587,7 +608,7 @@ describe('A path that forks and rejoins', () => {
 });
 
 describe('A single path with a pump', () => {
-  const parts: PersistentPart[] = [
+  const parts: StatePart[] = [
     {
       id: '1',
       x: 3,
@@ -598,6 +619,7 @@ describe('A single path with a pump', () => {
         pressure: 6,
         liquids: [COLD_WATER],
       },
+      state: {},
     },
     {
       id: '2',
@@ -609,6 +631,7 @@ describe('A single path with a pump', () => {
         disabled: true,
         pressure: 12,
       },
+      state: {},
     },
     {
       id: '3',
@@ -617,6 +640,7 @@ describe('A single path with a pump', () => {
       rotate: 0,
       type: 'SystemIO',
       settings: {},
+      state: {},
     },
   ];
 
@@ -725,7 +749,7 @@ describe('A single path with a pump', () => {
 
 
 describe('Two sources joining', () => {
-  const parts: PersistentPart[] = [
+  const parts: StatePart[] = [
     {
       id: '1',
       x: 1,
@@ -736,6 +760,7 @@ describe('Two sources joining', () => {
         pressure: 11,
         liquids: [COLD_WATER],
       },
+      state: {},
     },
     {
       id: '2',
@@ -747,6 +772,7 @@ describe('Two sources joining', () => {
         pressure: 11,
         liquids: [HOT_WATER],
       },
+      state: {},
     },
     {
       id: '3',
@@ -755,6 +781,7 @@ describe('Two sources joining', () => {
       rotate: 180,
       type: 'ElbowTube',
       settings: {},
+      state: {},
     },
     {
       id: '4',
@@ -763,6 +790,7 @@ describe('Two sources joining', () => {
       rotate: 270,
       type: 'ElbowTube',
       settings: {},
+      state: {},
     },
     {
       id: '5',
@@ -771,6 +799,7 @@ describe('Two sources joining', () => {
       rotate: 90,
       type: 'TeeTube',
       settings: {},
+      state: {},
     },
     {
       id: '6',
@@ -779,6 +808,7 @@ describe('Two sources joining', () => {
       rotate: 180,
       type: 'SystemIO',
       settings: {},
+      state: {},
     },
   ];
 
@@ -878,7 +908,7 @@ describe('Two sources joining', () => {
 
 
 describe('A path with a bridge', () => {
-  const parts: PersistentPart[] = [
+  const parts: StatePart[] = [
     {
       id: '1',
       x: 11,
@@ -889,6 +919,7 @@ describe('A path with a bridge', () => {
         liquids: [COLD_WATER],
         pressure: 8,
       },
+      state: {},
     },
     {
       id: '2',
@@ -897,6 +928,7 @@ describe('A path with a bridge', () => {
       type: 'StraightTube',
       rotate: 0,
       settings: {},
+      state: {},
     },
     {
       id: '3',
@@ -905,6 +937,7 @@ describe('A path with a bridge', () => {
       y: 2,
       rotate: 0,
       settings: {},
+      state: {},
     },
     {
       id: '4',
@@ -913,6 +946,7 @@ describe('A path with a bridge', () => {
       y: 1,
       rotate: 90,
       settings: {},
+      state: {},
     },
     {
       id: '5',
@@ -921,6 +955,7 @@ describe('A path with a bridge', () => {
       type: 'ElbowTube',
       rotate: 180,
       settings: {},
+      state: {},
     },
     {
       id: '6',
@@ -929,6 +964,7 @@ describe('A path with a bridge', () => {
       y: 3,
       rotate: 270,
       settings: {},
+      state: {},
     },
     {
       id: '7',
@@ -937,6 +973,7 @@ describe('A path with a bridge', () => {
       type: 'ElbowTube',
       rotate: 0,
       settings: {},
+      state: {},
     },
   ];
 


### PR DESCRIPTION
Resolves #495 

Catches datastore conflict errors, and reloads the data to avoid a failed state.

Actuator valves no longer update widget settings, but the component-local partState. This avoids automatically writing to the datastore every time an external Block changes state.

Debounced calculateFlows. updatePart and updatePartState trigger the function, which will wait 50 seconds, and then run once regardless of how often it was triggered. This also avoids calculating flow when other properties or data fields are changed.

When parts are updated, the local field is updated before the action is sent. This creates a temporary state that will be overridden by the next getter update, but avoids displaying the old state during the action round trip.