### PR TITLE
Feature/global disconnect warning

### DIFF
--- a/src/components/Watcher/ServiceWatchers.vue
+++ b/src/components/Watcher/ServiceWatchers.vue
@@ -1,0 +1,28 @@
+<script lang="ts">
+import Vue from 'vue';
+import Component from 'vue-class-component';
+import { serviceValues } from '@/store/services/getters';
+import { watcherById } from '@/store/providers/getters';
+
+@Component
+export default class ServiceWatchers extends Vue {
+  $q: any;
+
+  get watchers() {
+    return serviceValues(this.$store)
+      .map(service => ({ serviceId: service.id, component: watcherById(this.$store, service.type) }))
+      .filter(w => !!w.component);
+  }
+}
+</script>
+
+<template>
+  <div style="height: 0px; width: 0px;">
+    <component
+      v-for="watcher in watchers"
+      :key="watcher.serviceId"
+      :is="watcher.component"
+      :service-id="watcher.serviceId"
+    />
+  </div>
+</template>

--- a/src/components/Watcher/WatcherBase.ts
+++ b/src/components/Watcher/WatcherBase.ts
@@ -1,0 +1,20 @@
+import Component from 'vue-class-component';
+import Vue from 'vue';
+import { serviceById } from '@/store/services/getters';
+import { Service } from '@/store/services/state';
+
+@Component({
+  props: {
+    serviceId: {
+      type: String,
+      required: true,
+    },
+  },
+})
+export default class WatcherBase extends Vue {
+  protected $q: any;
+
+  protected get service(): Service {
+    return serviceById(this.$store, this.$props.serviceId);
+  }
+}

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -402,6 +402,8 @@ export default class DefaultLayout extends Vue {
       <WizardPicker v-if="wizardModalOpen" @close="wizardModalOpen = false"/>
     </q-dialog>
 
+    <ServiceWatchers/>
+
     <q-page-container>
       <router-view/>
     </q-page-container>

--- a/src/plugins/spark/features/ProcessView/components/ActuatorPartCard.vue
+++ b/src/plugins/spark/features/ProcessView/components/ActuatorPartCard.vue
@@ -1,107 +1,23 @@
 <script lang="ts">
 import PartCard from './PartCard';
 import Component from 'vue-class-component';
-import { serviceIds } from '@/store/services/getters';
-import { Block } from '@/plugins/spark/state';
-import { blockValues, blocks } from '@/plugins/spark/store/getters';
-import { objectStringSorter } from '@/helpers/functional';
-import { Link } from '@/helpers/units';
 
 @Component
 export default class ActuatorPartCard extends PartCard {
-  serviceId: string | null = null;
-  block: Block | null = null;
-
-  get supportedTypes() {
-    return [
-      'ActuatorPin',
-      'ActuatorDS2413',
-    ];
-  }
-
-  get serviceOptions() {
-    return serviceIds(this.$store);
-  }
-
-  get blockOptions() {
-    if (!this.serviceId) {
-      return [];
-    }
-
-    return blockValues(this.$store, this.serviceId)
-      .filter(block => this.supportedTypes.includes(block.type))
-      .sort(objectStringSorter('id'));
-  }
-
-  saveBlock() {
-    const updatedSettings = this.block
-      ? {
-        actuatorServiceId: this.serviceId,
-        actuatorLink: new Link(this.block.id, this.block.type),
-      }
-      : {
-        actuatorLink: null,
-      };
-
-    this.savePart({
-      ...this.part,
-      settings: {
-        ...this.part.settings,
-        ...updatedSettings,
-      },
-    });
-  }
-
-  mounted() {
-    this.serviceId = this.part.settings.actuatorServiceId || null;
-    if (this.serviceId && this.part.settings.actuatorLink) {
-      this.block = blocks(this.$store, this.serviceId as string)[this.part.settings.actuatorLink.id];
-    }
+  get blockCardProps() {
+    return {
+      ...this.$props,
+      types: [
+        'ActuatorPin',
+        'ActuatorDS2413',
+      ],
+      blockServiceIdKey: 'actuatorServiceId',
+      blockLinkKey: 'actuatorLink',
+    };
   }
 }
 </script>
 
 <template>
-  <q-list dark>
-    <q-separator dark/>
-    <q-item dark>
-      <q-item-section>
-        <q-select v-model="serviceId" :options="serviceOptions" dark options-dark label="Service">
-          <template v-slot:no-option>
-            <q-item dark>
-              <q-item-section class="text-grey">No results</q-item-section>
-            </q-item>
-          </template>
-        </q-select>
-      </q-item-section>
-    </q-item>
-    <q-item dark>
-      <q-item-section>
-        <q-select
-          v-model="block"
-          :options="blockOptions"
-          dark
-          options-dark
-          label="Actuator"
-          option-label="id"
-          option-value="id"
-        >
-          <template v-slot:no-option>
-            <q-item dark>
-              <q-item-section v-if="serviceId" class="text-grey">No results</q-item-section>
-              <q-item-section v-else class="text-grey">Please select a service</q-item-section>
-            </q-item>
-          </template>
-          <template v-slot:append>
-            <q-btn flat round icon="mdi-close-circle" @click.stop="block = null"/>
-          </template>
-        </q-select>
-      </q-item-section>
-    </q-item>
-    <q-item dark>
-      <q-item-section>
-        <q-btn label="Save" unelevated color="primary" @click="saveBlock"/>
-      </q-item-section>
-    </q-item>
-  </q-list>
+  <BlockPartCard v-bind="blockCardProps" v-on="$listeners"/>
 </template>

--- a/src/plugins/spark/features/ProcessView/components/BlockPartCard.vue
+++ b/src/plugins/spark/features/ProcessView/components/BlockPartCard.vue
@@ -1,0 +1,117 @@
+<script lang="ts">
+import PartCard from './PartCard';
+import Component from 'vue-class-component';
+import { serviceIds } from '@/store/services/getters';
+import { Block } from '@/plugins/spark/state';
+import { blockValues, blocks } from '@/plugins/spark/store/getters';
+import { objectStringSorter } from '@/helpers/functional';
+import get from 'lodash/get';
+import { Link } from '@/helpers/units';
+
+@Component({
+  props: {
+    types: {
+      type: Array,
+      required: true,
+    },
+    blockServiceIdKey: {
+      type: String,
+      default: 'blockServiceId',
+    },
+    blockLinkKey: {
+      type: String,
+      default: 'blockLink',
+    },
+  },
+})
+export default class BlockPartCard extends PartCard {
+  serviceId: string | null = null;
+  block: Block | null = null;
+
+  get serviceOptions() {
+    return serviceIds(this.$store);
+  }
+
+  get blockOptions() {
+    if (!this.serviceId) {
+      return [];
+    }
+
+    return blockValues(this.$store, this.serviceId)
+      .filter(block => this.$props.types.includes(block.type))
+      .sort(objectStringSorter('id'));
+  }
+
+  saveBlock() {
+    const updatedSettings = this.block
+      ? {
+        [this.$props.blockServiceIdKey]: this.serviceId,
+        [this.$props.blockLinkKey]: new Link(this.block.id, this.block.type),
+      }
+      : {
+        [this.$props.blockLinkKey]: null,
+      };
+
+    this.savePart({
+      ...this.part,
+      settings: {
+        ...this.part.settings,
+        ...updatedSettings,
+      },
+    });
+  }
+
+  mounted() {
+    this.serviceId = get(this.part.settings, this.$props.blockServiceIdKey, null);
+    const link = get(this.part.settings, this.$props.blockLinkKey, null);
+    if (this.serviceId && link) {
+      this.block = blocks(this.$store, this.serviceId as string)[link.id];
+    }
+  }
+}
+</script>
+
+<template>
+  <q-list dark>
+    <q-separator dark/>
+    <q-item dark>
+      <q-item-section>
+        <q-select v-model="serviceId" :options="serviceOptions" dark options-dark label="Service">
+          <template v-slot:no-option>
+            <q-item dark>
+              <q-item-section class="text-grey">No results</q-item-section>
+            </q-item>
+          </template>
+        </q-select>
+      </q-item-section>
+    </q-item>
+    <q-item dark>
+      <q-item-section>
+        <q-select
+          v-model="block"
+          :options="blockOptions"
+          dark
+          options-dark
+          label="Sensor"
+          option-label="id"
+          option-value="id"
+        >
+          <template v-slot:no-option>
+            <q-item dark>
+              <q-item-section v-if="serviceId" class="text-grey">No results</q-item-section>
+              <q-item-section v-else class="text-grey">Please select a service</q-item-section>
+            </q-item>
+          </template>
+          <template v-slot:append>
+            <q-btn flat round icon="mdi-close-circle" @click.stop="block = null"/>
+          </template>
+        </q-select>
+      </q-item-section>
+    </q-item>
+    <q-item dark>
+      <q-item-section>
+        <q-btn label="Save" unelevated color="primary" @click="saveBlock"/>
+      </q-item-section>
+    </q-item>
+  </q-list>
+</template>

--- a/src/plugins/spark/features/ProcessView/components/PwmPartCard.vue
+++ b/src/plugins/spark/features/ProcessView/components/PwmPartCard.vue
@@ -1,106 +1,20 @@
 <script lang="ts">
 import PartCard from './PartCard';
 import Component from 'vue-class-component';
-import { serviceIds } from '@/store/services/getters';
-import { Block } from '@/plugins/spark/state';
-import { blockValues, blocks } from '@/plugins/spark/store/getters';
-import { objectStringSorter } from '@/helpers/functional';
-import { Link } from '@/helpers/units';
 
 @Component
 export default class PwmPartCard extends PartCard {
-  serviceId: string | null = null;
-  block: Block | null = null;
-
-  get supportedBlocks() {
-    return [
-      'ActuatorPwm',
-    ];
-  }
-
-  get serviceOptions() {
-    return serviceIds(this.$store);
-  }
-
-  get blockOptions() {
-    if (!this.serviceId) {
-      return [];
-    }
-
-    return blockValues(this.$store, this.serviceId)
-      .filter(block => this.supportedBlocks.includes(block.type))
-      .sort(objectStringSorter('id'));
-  }
-
-  saveBlock() {
-    const updatedSettings = this.block
-      ? {
-        blockServiceId: this.serviceId,
-        blockLink: new Link(this.block.id, this.block.type),
-      }
-      : {
-        blockLink: null,
-      };
-
-    this.savePart({
-      ...this.part,
-      settings: {
-        ...this.part.settings,
-        ...updatedSettings,
-      },
-    });
-  }
-
-  mounted() {
-    this.serviceId = this.part.settings.blockServiceId || null;
-    if (this.serviceId && this.part.settings.blockLink) {
-      this.block = blocks(this.$store, this.serviceId as string)[this.part.settings.blockLink.id];
-    }
+  get blockCardProps() {
+    return {
+      ...this.$props,
+      types: [
+        'ActuatorPwm',
+      ],
+    };
   }
 }
 </script>
 
 <template>
-  <q-list dark>
-    <q-separator dark/>
-    <q-item dark>
-      <q-item-section>
-        <q-select v-model="serviceId" :options="serviceOptions" dark options-dark label="Service">
-          <template v-slot:no-option>
-            <q-item dark>
-              <q-item-section class="text-grey">No results</q-item-section>
-            </q-item>
-          </template>
-        </q-select>
-      </q-item-section>
-    </q-item>
-    <q-item dark>
-      <q-item-section>
-        <q-select
-          v-model="block"
-          :options="blockOptions"
-          dark
-          options-dark
-          label="Sensor"
-          option-label="id"
-          option-value="id"
-        >
-          <template v-slot:no-option>
-            <q-item dark>
-              <q-item-section v-if="serviceId" class="text-grey">No results</q-item-section>
-              <q-item-section v-else class="text-grey">Please select a service</q-item-section>
-            </q-item>
-          </template>
-          <template v-slot:append>
-            <q-btn flat round icon="mdi-close-circle" @click.stop="block = null"/>
-          </template>
-        </q-select>
-      </q-item-section>
-    </q-item>
-    <q-item dark>
-      <q-item-section>
-        <q-btn label="Save" unelevated color="primary" @click="saveBlock"/>
-      </q-item-section>
-    </q-item>
-  </q-list>
+  <BlockPartCard v-bind="blockCardProps" v-on="$listeners"/>
 </template>

--- a/src/plugins/spark/features/ProcessView/components/PwmPartCard.vue
+++ b/src/plugins/spark/features/ProcessView/components/PwmPartCard.vue
@@ -1,0 +1,106 @@
+<script lang="ts">
+import PartCard from './PartCard';
+import Component from 'vue-class-component';
+import { serviceIds } from '@/store/services/getters';
+import { Block } from '@/plugins/spark/state';
+import { blockValues, blocks } from '@/plugins/spark/store/getters';
+import { objectStringSorter } from '@/helpers/functional';
+import { Link } from '@/helpers/units';
+
+@Component
+export default class PwmPartCard extends PartCard {
+  serviceId: string | null = null;
+  block: Block | null = null;
+
+  get supportedBlocks() {
+    return [
+      'ActuatorPwm',
+    ];
+  }
+
+  get serviceOptions() {
+    return serviceIds(this.$store);
+  }
+
+  get blockOptions() {
+    if (!this.serviceId) {
+      return [];
+    }
+
+    return blockValues(this.$store, this.serviceId)
+      .filter(block => this.supportedBlocks.includes(block.type))
+      .sort(objectStringSorter('id'));
+  }
+
+  saveBlock() {
+    const updatedSettings = this.block
+      ? {
+        blockServiceId: this.serviceId,
+        blockLink: new Link(this.block.id, this.block.type),
+      }
+      : {
+        blockLink: null,
+      };
+
+    this.savePart({
+      ...this.part,
+      settings: {
+        ...this.part.settings,
+        ...updatedSettings,
+      },
+    });
+  }
+
+  mounted() {
+    this.serviceId = this.part.settings.blockServiceId || null;
+    if (this.serviceId && this.part.settings.blockLink) {
+      this.block = blocks(this.$store, this.serviceId as string)[this.part.settings.blockLink.id];
+    }
+  }
+}
+</script>
+
+<template>
+  <q-list dark>
+    <q-separator dark/>
+    <q-item dark>
+      <q-item-section>
+        <q-select v-model="serviceId" :options="serviceOptions" dark options-dark label="Service">
+          <template v-slot:no-option>
+            <q-item dark>
+              <q-item-section class="text-grey">No results</q-item-section>
+            </q-item>
+          </template>
+        </q-select>
+      </q-item-section>
+    </q-item>
+    <q-item dark>
+      <q-item-section>
+        <q-select
+          v-model="block"
+          :options="blockOptions"
+          dark
+          options-dark
+          label="Sensor"
+          option-label="id"
+          option-value="id"
+        >
+          <template v-slot:no-option>
+            <q-item dark>
+              <q-item-section v-if="serviceId" class="text-grey">No results</q-item-section>
+              <q-item-section v-else class="text-grey">Please select a service</q-item-section>
+            </q-item>
+          </template>
+          <template v-slot:append>
+            <q-btn flat round icon="mdi-close-circle" @click.stop="block = null"/>
+          </template>
+        </q-select>
+      </q-item-section>
+    </q-item>
+    <q-item dark>
+      <q-item-section>
+        <q-btn label="Save" unelevated color="primary" @click="saveBlock"/>
+      </q-item-section>
+    </q-item>
+  </q-list>
+</template>

--- a/src/plugins/spark/features/ProcessView/components/SensorPartCard.vue
+++ b/src/plugins/spark/features/ProcessView/components/SensorPartCard.vue
@@ -1,107 +1,23 @@
 <script lang="ts">
 import PartCard from './PartCard';
 import Component from 'vue-class-component';
-import { serviceIds } from '@/store/services/getters';
-import { Block } from '@/plugins/spark/state';
-import { blockValues, blocks } from '@/plugins/spark/store/getters';
-import { objectStringSorter } from '@/helpers/functional';
-import { Link } from '@/helpers/units';
 
 @Component
 export default class SensorPartCard extends PartCard {
-  serviceId: string | null = null;
-  block: Block | null = null;
-
-  get supportedSensors() {
-    return [
-      'TempSensorMock',
-      'TempSensorOneWire',
-    ];
-  }
-
-  get serviceOptions() {
-    return serviceIds(this.$store);
-  }
-
-  get blockOptions() {
-    if (!this.serviceId) {
-      return [];
-    }
-
-    return blockValues(this.$store, this.serviceId)
-      .filter(block => this.supportedSensors.includes(block.type))
-      .sort(objectStringSorter('id'));
-  }
-
-  saveSensor() {
-    const updatedSettings = this.block
-      ? {
-        sensorServiceId: this.serviceId,
-        sensorLink: new Link(this.block.id, this.block.type),
-      }
-      : {
-        sensorLink: null,
-      };
-
-    this.savePart({
-      ...this.part,
-      settings: {
-        ...this.part.settings,
-        ...updatedSettings,
-      },
-    });
-  }
-
-  mounted() {
-    this.serviceId = this.part.settings.sensorServiceId || null;
-    if (this.serviceId && this.part.settings.sensorLink) {
-      this.block = blocks(this.$store, this.serviceId as string)[this.part.settings.sensorLink.id];
-    }
+  get blockCardProps() {
+    return {
+      ...this.$props,
+      types: [
+        'TempSensorMock',
+        'TempSensorOneWire',
+      ],
+      blockServiceIdKey: 'sensorServiceId',
+      blockLinkKey: 'sensorLink',
+    };
   }
 }
 </script>
 
 <template>
-  <q-list dark>
-    <q-separator dark/>
-    <q-item dark>
-      <q-item-section>
-        <q-select v-model="serviceId" :options="serviceOptions" dark options-dark label="Service">
-          <template v-slot:no-option>
-            <q-item dark>
-              <q-item-section class="text-grey">No results</q-item-section>
-            </q-item>
-          </template>
-        </q-select>
-      </q-item-section>
-    </q-item>
-    <q-item dark>
-      <q-item-section>
-        <q-select
-          v-model="block"
-          :options="blockOptions"
-          dark
-          options-dark
-          label="Sensor"
-          option-label="id"
-          option-value="id"
-        >
-          <template v-slot:no-option>
-            <q-item dark>
-              <q-item-section v-if="serviceId" class="text-grey">No results</q-item-section>
-              <q-item-section v-else class="text-grey">Please select a service</q-item-section>
-            </q-item>
-          </template>
-          <template v-slot:append>
-            <q-btn flat round icon="mdi-close-circle" @click.stop="block = null"/>
-          </template>
-        </q-select>
-      </q-item-section>
-    </q-item>
-    <q-item dark>
-      <q-item-section>
-        <q-btn label="Save" unelevated color="primary" @click="saveSensor"/>
-      </q-item-section>
-    </q-item>
-  </q-list>
+  <BlockPartCard v-bind="blockCardProps" v-on="$listeners"/>
 </template>

--- a/src/plugins/spark/features/ProcessView/parts/HeatingElement.vue
+++ b/src/plugins/spark/features/ProcessView/parts/HeatingElement.vue
@@ -1,6 +1,10 @@
 <script lang="ts">
 import Component from 'vue-class-component';
 import PartComponent from '../components/PartComponent';
+import { SQUARE_SIZE } from '../getters';
+import { blocks } from '@/plugins/spark/store/getters';
+import get from 'lodash/get';
+import { Link } from '@/helpers/units';
 
 @Component
 export default class HeatingElement extends PartComponent {
@@ -10,21 +14,58 @@ export default class HeatingElement extends PartComponent {
         'M0,10l0,30h19v-7h-6.5c0,0,0,0,0,0c-4.1,0.1-7.4-3.2-7.5-7.2c0-4.7,2.8-7.8,7.5-7.8H19v-8H0z',
       ],
       borders: [
-        'M52.6,24.7h21c7.1,0,6.6-6.7,14-6.7h126.9c0,0,7,0.1,7,7c0,7-7,7-7,7H90',
+        'M50,24.7h24c7.1,0,6.6-6.7,14-6.7h126.9c0,0,7,0.1,7,7c0,7-7,7-7,7H90',
       ],
     };
+  }
+
+  get textTransformation() {
+    return `rotate(${-this.part.rotate},${SQUARE_SIZE / 2},${SQUARE_SIZE / 2})`;
+  }
+
+  get blockServiceId(): string {
+    return this.part.settings.blockServiceId;
+  }
+
+  get blockLink(): Link {
+    return this.part.settings.blockLink;
+  }
+
+  get blockValue(): number | null {
+    if (!this.blockServiceId || !this.blockLink || !this.blockLink.id) {
+      return null;
+    }
+
+    return get(
+      blocks(this.$store, this.blockServiceId),
+      [this.blockLink.id, 'data', 'value'],
+      null
+    );
   }
 }
 </script>
 
 <template>
   <g class="heating-element">
-    <g class="text">
-      <text x="10" y="30">20°</text>
-    </g>
+    <foreignObject :transform="textTransformation" :width="SQUARE_SIZE" :height="SQUARE_SIZE">
+      <div class="text-white text-bold text-center">
+        <span>%</span>
+        <q-icon v-if="!blockLink" name="mdi-link-variant-off"/>
+        <br>
+        <span>{{ blockValue | round }}</span>
+      </div>
+    </foreignObject>
     <g class="outline">
-      <rect x="0" y="10" width="50" height="30" rx="10" ry="10"/>
       <path v-for="border in paths.borders" :key="border" :d="border"/>
+      <rect
+        :width="SQUARE_SIZE-2"
+        :height="SQUARE_SIZE-2"
+        x="1"
+        y="1"
+        rx="6"
+        ry="6"
+        stroke-width="2px"
+      />
     </g>
   </g>
 </template>

--- a/src/plugins/spark/features/ProcessView/settings/HeatingElement.ts
+++ b/src/plugins/spark/features/ProcessView/settings/HeatingElement.ts
@@ -13,6 +13,7 @@ const SIZE_Y = 1;
 
 const settings: ComponentSettings = {
   ...defaultSettings,
+  cards: ['PwmPartCard'],
   size: () => [SIZE_X, SIZE_Y],
   transitions: () => ({}),
   blockedCoordinates: (part: PersistentPart): Coordinates[] =>

--- a/src/plugins/spark/index.ts
+++ b/src/plugins/spark/index.ts
@@ -64,5 +64,6 @@ export default ({ store }: PluginArguments) => {
     fetcher: fetchAll,
     wizard: 'SparkWizard',
     page: 'SparkPage',
+    watcher: 'SparkWatcher',
   });
 };

--- a/src/plugins/spark/provider/SparkWatcher.vue
+++ b/src/plugins/spark/provider/SparkWatcher.vue
@@ -1,0 +1,52 @@
+<script lang="ts">
+import Component from 'vue-class-component';
+import { updateSource } from '../store/getters';
+import { fetchServiceStatus, createUpdateSource } from '../store/actions';
+import WatcherBase from '@/components/Watcher/WatcherBase';
+
+@Component
+export default class SparkWatcher extends WatcherBase {
+  dismissFunc: Function | null = null;
+
+  get updating() {
+    return updateSource(this.$store, this.service.id) !== null;
+  }
+
+  retryUpdateSource() {
+    fetchServiceStatus(this.$store, this.service.id);
+    createUpdateSource(this.$store, this.service.id);
+  }
+
+  handleUpdateChange(updating: boolean) {
+    if (!updating && !this.dismissFunc) {
+      this.dismissFunc = this.$q.notify({
+        timeout: 0,
+        color: 'warning',
+        icon: 'warning',
+        message: `Lost connection to ${this.service.title}`,
+        actions: [
+          {
+            label: 'Retry',
+            textColor: 'white',
+            handler: this.retryUpdateSource,
+          },
+        ],
+      });
+      return;
+    }
+
+    if (updating && this.dismissFunc) {
+      this.dismissFunc();
+      this.dismissFunc = null;
+    }
+  }
+
+  mounted() {
+    this.$watch('updating', this.handleUpdateChange);
+  }
+}
+</script>
+
+<template>
+  <div/>
+</template>

--- a/src/plugins/spark/store/api.ts
+++ b/src/plugins/spark/store/api.ts
@@ -17,7 +17,10 @@ const asBlock = (block: DataBlock, serviceId: string): Block => ({ ...block, ser
 
 const intercept = (message: string): (e: Error) => never =>
   (e: Error) => {
-    Notify.create(`${message}: ${e.message}`);
+    Notify.create({
+      icon: 'warning',
+      message: `${message}: ${e.message}`,
+    });
     throw e;
   };
 

--- a/src/store/providers/getters.ts
+++ b/src/store/providers/getters.ts
@@ -39,5 +39,8 @@ export const wizardById =
 export const pageById =
   (store: RootStore, id: string): string | undefined => providerById(store, id).page;
 
+export const watcherById =
+  (store: RootStore, id: string): string | undefined => providerById(store, id).watcher;
+
 export const featuresById =
   (store: RootStore, id: string): string[] => providerById(store, id).features;

--- a/src/store/providers/state.d.ts
+++ b/src/store/providers/state.d.ts
@@ -10,6 +10,7 @@ export interface Provider {
   fetcher?: (store: RootStore, service: Service) => Promise<any>;
   wizard?: string;
   page?: string;
+  watcher?: string;
 }
 
 export interface ProviderState {


### PR DESCRIPTION
Resolves #496 

Providers can now also declare an optional `watcher` component. This component is always rendered 0x0, but is permanently mounted. 

DefaultLayout now has the ServiceWatchers component, which mounts a watcher for each service that has one.

SparkWatcher watches the update source, and displays a notification with a retry button when it is closed. It will automatically dismiss the notification when a new update source is created.