### PR TITLE
fix data format bug in setpoint profile

### DIFF
--- a/dev/presets/spark_blocks.json
+++ b/dev/presets/spark_blocks.json
@@ -24,17 +24,18 @@
     ],
     "type": "SetpointProfile",
     "data": {
+      "start": 1540376829,
       "points": [
         {
-          "time": 1540376829,
+          "time": 10,
           "temperature[degC]": 0
         },
         {
-          "time": 1540376839,
+          "time": 20,
           "temperature[degC]": 50
         },
         {
-          "time": 1540376849,
+          "time": 30000,
           "temperature[degC]": 100
         }
       ]

--- a/src/components/PopupEdit/DatetimePopupEdit.vue
+++ b/src/components/PopupEdit/DatetimePopupEdit.vue
@@ -41,7 +41,7 @@ export default class DatetimePopupEdit extends Vue {
     qTimeProxy: any;
   }
 
-  placeholder: any = NaN; // must not equal clear-value
+  placeholder: Date | null = null;
   timePlaceholder = '';
   datePlaceholder = '';
 

--- a/src/plugins/spark/features/SetpointProfile/SetpointProfileForm.vue
+++ b/src/plugins/spark/features/SetpointProfile/SetpointProfileForm.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { durationString, objectSorter } from '@/helpers/functional';
-import { Unit } from '@/helpers/units';
+import { Unit, Link } from '@/helpers/units';
 import BlockForm from '@/plugins/spark/components/BlockForm';
 import { units } from '@/plugins/spark/store/getters';
 import parseDuration from 'parse-duration';
@@ -42,10 +42,11 @@ export default class SetpointProfileForm extends BlockForm {
 
   defaultData() {
     return {
-      points: [],
-      setting: new Unit(null, 'degC'),
-      enabled: true,
       start: new Date().getTime() / 1000,
+      points: [],
+      enabled: false,
+      targetId: new Link(null),
+      drivenTargetId: new Link(null),
     };
   }
 
@@ -55,7 +56,6 @@ export default class SetpointProfileForm extends BlockForm {
         label: 'Empty profile',
         value: {
           points: [],
-          setting: new Unit(null, 'degC'),
           enabled: true,
           start: new Date().getTime() / 1000,
         },

--- a/src/plugins/spark/features/SetpointProfile/SetpointProfileWidget.vue
+++ b/src/plugins/spark/features/SetpointProfile/SetpointProfileWidget.vue
@@ -14,11 +14,15 @@ export default class SetpointProfileWidget extends BlockWidget {
     return getById(this.$store, this.serviceId, this.blockId);
   }
 
+  get startTime(): number {
+    return this.block.data.start * 1000;
+  }
+
   get plotlyData(): Partial<PlotData>[] {
     return [{
       name: 'Setpoints',
       type: 'scatter',
-      x: this.block.data.points.map(p => p.time * 1000),
+      x: this.block.data.points.map(p => this.startTime + (p.time * 1000)),
       y: this.block.data.points.map(p => p.temperature.value),
     }];
   }

--- a/src/plugins/spark/features/SetpointProfile/state.d.ts
+++ b/src/plugins/spark/features/SetpointProfile/state.d.ts
@@ -12,5 +12,6 @@ export interface SetpointProfileBlock extends Block {
     points: Setpoint[];
     enabled: boolean;
     targetId: Link;
+    drivenTargetId: Link;
   };
 }

--- a/src/plugins/spark/features/SetpointProfile/state.d.ts
+++ b/src/plugins/spark/features/SetpointProfile/state.d.ts
@@ -8,6 +8,7 @@ export interface Setpoint {
 
 export interface SetpointProfileBlock extends Block {
   data: {
+    start: number;
     points: Setpoint[];
     enabled: boolean;
     targetId: Link;


### PR DESCRIPTION
Resolves #505 

In the UI refactor, DatetimePopupEdit changed its output format from `number` to `Date`. This caused comparison issues in SetpointProfile.

Added explanation text to popup edit fields in form to clarify how the edit will change points.