### PR TITLE
Feature/flipped parts

### DIFF
--- a/src/helpers/coordinates.ts
+++ b/src/helpers/coordinates.ts
@@ -3,6 +3,13 @@ import { clampRotation } from './functional';
 export type CoordinatesParam =
   string | { x: number; y: number; z: number } | [number, number, number] | Coordinates;
 
+export const rotatedSize =
+  (rotation: number, size: [number, number]): [number, number] =>
+    clampRotation(rotation) % 180 > 0
+      ? [size[1], size[0]]
+      : [size[0], size[1]];
+
+
 export class Coordinates {
   public readonly x: number;
   public readonly y: number;
@@ -134,10 +141,7 @@ export class Coordinates {
     // Step 1 - start
     const squareAnchor = this;
     const shapeAnchor = new Coordinates(shapeCoordinates);
-    const [newSizeX, newSizeY] =
-      (totalRotation % 180 > 0)
-        ? [...shapeSize].reverse()
-        : [...shapeSize];
+    const [newSizeX, newSizeY] = rotatedSize(totalRotation, shapeSize);
 
     const rotatedSquareCenter = squareAnchor
       // Step 2 - shift from square anchor to center
@@ -189,6 +193,27 @@ export class Coordinates {
       .rotate(rotation, rotatedSquareAnchor.translate([0.5, 0.5, 0]));
 
     return rotatedEdge;
+  }
+
+  public flipShapeEdge(
+    flip: boolean, // allows chained syntax with optional flips
+    shapeRotation: number,
+    shapeSize: [number, number],
+    shapeCoordinates: CoordinatesParam = [0, 0, 0],
+  ): Coordinates {
+    if (this.isException() || !flip) {
+      return new Coordinates(this);
+    }
+
+    // Step 1 - start
+    const shape = new Coordinates(shapeCoordinates);
+
+    // Step 2 - shift in X past the midpoint
+    const [sizeX] = rotatedSize(shapeRotation, shapeSize);
+    const shiftX = ((shape.x + (sizeX / 2)) - this.x) * 2;
+    const flippedEdge = this.translate([shiftX, 0, 0]);
+
+    return flippedEdge;
   }
 
   public toString(): string {

--- a/src/plugins/spark/features/ProcessView/ProcessViewForm.vue
+++ b/src/plugins/spark/features/ProcessView/ProcessViewForm.vue
@@ -146,6 +146,14 @@ export default class ProcessViewForm extends FormBase {
         onClick: this.rotateClickHandler,
       },
       {
+        label: 'Flip (Click)',
+        value: 'flip',
+        icon: 'mdi-swap-horizontal-bold',
+        shortcut: 'f',
+        cursor: part => !!part,
+        onClick: this.flipClickHandler,
+      },
+      {
         label: 'Edit Settings (Click)',
         value: 'config',
         icon: 'settings',
@@ -294,6 +302,12 @@ export default class ProcessViewForm extends FormBase {
     if (part) {
       const rotate = clampRotation(part.rotate + rotation);
       this.updatePart({ ...part, rotate });
+    }
+  }
+
+  flipClickHandler(evt: ClickEvent, part: FlowPart) {
+    if (part) {
+      this.updatePart({ ...part, flipped: !part.flipped });
     }
   }
 

--- a/src/plugins/spark/features/ProcessView/ProcessViewForm.vue
+++ b/src/plugins/spark/features/ProcessView/ProcessViewForm.vue
@@ -21,6 +21,7 @@ interface ToolAction {
   label: string;
   value: string;
   icon: string;
+  shortcut: string;
   cursor: (part: FlowPart) => boolean;
   onClick?: (evt: ClickEvent, part: FlowPart) => void;
   onPan?: (args: PanArguments, part: FlowPart) => void;
@@ -124,6 +125,7 @@ export default class ProcessViewForm extends FormBase {
         label: 'New (Click)',
         value: 'add',
         icon: 'add',
+        shortcut: 'n',
         cursor: () => false,
         onClick: this.addPartClickHandler,
       },
@@ -131,6 +133,7 @@ export default class ProcessViewForm extends FormBase {
         label: 'Move (Drag)',
         value: 'move',
         icon: 'mdi-cursor-move',
+        shortcut: 'm',
         cursor: part => !!part,
         onPan: this.movePanHandler,
       },
@@ -138,6 +141,7 @@ export default class ProcessViewForm extends FormBase {
         label: 'Rotate (Click)',
         value: 'rotate-right',
         icon: 'mdi-rotate-right-variant',
+        shortcut: 'r',
         cursor: part => !!part,
         onClick: this.rotateClickHandler,
       },
@@ -145,6 +149,7 @@ export default class ProcessViewForm extends FormBase {
         label: 'Edit Settings (Click)',
         value: 'config',
         icon: 'settings',
+        shortcut: 'e',
         cursor: part => !!part,
         onClick: this.configurePartClickHandler,
       },
@@ -152,6 +157,7 @@ export default class ProcessViewForm extends FormBase {
         label: 'Interact (Click)',
         value: 'interact',
         icon: 'mdi-cursor-default',
+        shortcut: 'i',
         cursor: part => !!part && !!settings[part.type].interactHandler,
         onClick: this.interactClickHandler,
       },
@@ -159,6 +165,7 @@ export default class ProcessViewForm extends FormBase {
         label: 'Copy (Drag)',
         value: 'copy',
         icon: 'file_copy',
+        shortcut: 'c',
         cursor: part => !!part,
         onPan: this.copyPanHandler,
       },
@@ -166,6 +173,7 @@ export default class ProcessViewForm extends FormBase {
         label: 'Delete (Click)',
         value: 'delete',
         icon: 'delete',
+        shortcut: 'd',
         cursor: part => !!part,
         onClick: (evt, part) => this.removePart(part),
       },
@@ -332,6 +340,23 @@ export default class ProcessViewForm extends FormBase {
       && this.dragAction.hide
       && this.dragAction.part.id === part.id;
   }
+
+  keyHandler(evt: KeyboardEvent) {
+    const key = evt.key.toLowerCase();
+    const tool = this.tools.find(t => t.shortcut === key);
+    if (tool) {
+      this.currentTool = tool;
+      evt.stopPropagation();
+    }
+  }
+
+  mounted() {
+    window.addEventListener('keyup', this.keyHandler);
+  }
+
+  destroyed() {
+    window.removeEventListener('keyup', this.keyHandler);
+  }
 }
 </script>
 
@@ -374,7 +399,9 @@ export default class ProcessViewForm extends FormBase {
           :label="tool.label"
           no-close
           @click="currentTool = tool"
-        />
+        >
+          <q-item-section side class="text-uppercase">{{ tool.shortcut }}</q-item-section>
+        </ActionItem>
 
         <q-item/>
         <q-item dark dense>

--- a/src/plugins/spark/features/ProcessView/calculateFlows.ts
+++ b/src/plugins/spark/features/ProcessView/calculateFlows.ts
@@ -51,11 +51,13 @@ const normalizeFlows = (part: FlowPart): FlowPart => {
   if (!part.flows) {
     return { ...part, flows: {} };
   }
+  const size = partSize(part);
 
   const newFlows = mapKeys(part.flows,
     (flow, inCoord) =>
       new Coordinates(inCoord)
         .translate([-part.x, -part.y, 0])
+        .flipShapeEdge(!!part.flipped, part.rotate, size)
         .toString()
   );
 
@@ -71,6 +73,7 @@ const translations = (part: StatePart): Transitions =>
       const size = partSize(part);
 
       const updatedKey = new Coordinates(inCoordStr)
+        .flipShapeEdge(!!part.flipped, 0, size)
         .translate([part.x, part.y, 0])
         .rotateShapeEdge(part.rotate, 0, size, [part.x, part.y, 0])
         .toString();
@@ -79,6 +82,7 @@ const translations = (part: StatePart): Transitions =>
         .map((route: FlowRoute) => ({
           ...route,
           outCoords: new Coordinates(route.outCoords)
+            .flipShapeEdge(!!part.flipped, 0, size)
             .translate([part.x, part.y, 0])
             .rotateShapeEdge(part.rotate, 0, size, [part.x, part.y, 0])
             .toString(),

--- a/src/plugins/spark/features/ProcessView/components/PartComponent.ts
+++ b/src/plugins/spark/features/ProcessView/components/PartComponent.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import Component from 'vue-class-component';
 import { FlowPart, CalculatedFlows } from '../state';
 import partSettings from '../settings';
-import { Coordinates } from '@/helpers/coordinates';
+import { Coordinates, rotatedSize } from '@/helpers/coordinates';
 import { SQUARE_SIZE } from '../getters';
 
 @Component({
@@ -54,6 +54,15 @@ export default class PartComponent extends Vue {
 
   protected get sizeY(): number {
     return this.size[1];
+  }
+
+  protected textTransformation(textSize: [number, number]): string {
+    const [sizeX] = rotatedSize(this.part.rotate, textSize);
+    const rotate = `rotate(${-this.part.rotate},${SQUARE_SIZE / 2},${SQUARE_SIZE / 2})`;
+    const flip = `translate(${sizeX * SQUARE_SIZE}, 0) scale(-1,1)`;
+    return this.flipped
+      ? `${flip} ${rotate}`
+      : rotate;
   }
 
   private rotatedCoord(coord: string): string {

--- a/src/plugins/spark/features/ProcessView/components/PlacementPartCard.vue
+++ b/src/plugins/spark/features/ProcessView/components/PlacementPartCard.vue
@@ -39,8 +39,12 @@ export default class PlacementPartCard extends PartCard {
         />
       </q-item-section>
       <q-item-section>
-        <q-btn disable color="primary" icon="mdi-swap-horizontal-bold" label="flip" @click="flip"/>
-        <q-tooltip>Disabled until part flipping is fixed</q-tooltip>
+        <q-btn
+          :label="part.flipped ? 'unflip' : 'flip'"
+          color="primary"
+          icon="mdi-swap-horizontal-bold"
+          @click="flip"
+        />
       </q-item-section>
       <q-item-section>
         <q-btn color="primary" icon="delete" label="delete" @click="removePart"/>

--- a/src/plugins/spark/features/ProcessView/components/ProcessViewItem.vue
+++ b/src/plugins/spark/features/ProcessView/components/ProcessViewItem.vue
@@ -2,7 +2,7 @@
 import Vue from 'vue';
 import Component from 'vue-class-component';
 import { SQUARE_SIZE } from '../getters';
-import { Coordinates } from '@/helpers/coordinates';
+import { Coordinates, rotatedSize } from '@/helpers/coordinates';
 import { FlowPart } from '../state';
 import settings from '../settings';
 
@@ -34,16 +34,9 @@ export default class ProcessViewItem extends Vue {
     return this.settings.size(this.part);
   }
 
-  get renderSize() {
+  get rotateTransform() {
     const [partSizeX, partSizeY] = this.partSize;
-    return (this.part.rotate % 180 > 0)
-      ? [partSizeY, partSizeX]
-      : [partSizeX, partSizeY];
-  }
-
-  get transformation() {
-    const [partSizeX, partSizeY] = this.partSize;
-    const [renderSizeX, renderSizeY] = this.renderSize;
+    const [renderSizeX, renderSizeY] = rotatedSize(this.part.rotate, this.partSize);
 
     const farEdge = new Coordinates([partSizeX, partSizeY, 0])
       .rotate(this.part.rotate, [0, 0, 0]);
@@ -52,6 +45,18 @@ export default class ProcessViewItem extends Vue {
     const trY = farEdge.y < 0 ? (renderSizeY * SQUARE_SIZE) : 0;
 
     return `translate(${trX}, ${trY}) rotate(${this.part.rotate})`;
+  }
+
+  get flipTransform() {
+    if (!this.part.flipped) {
+      return '';
+    }
+    const sizeX = this.partSize[0];
+    return `translate(${sizeX * SQUARE_SIZE}, 0) scale(-1, 1)`;
+  }
+
+  get transformation() {
+    return `${this.rotateTransform} ${this.flipTransform}`;
   }
 }
 </script>

--- a/src/plugins/spark/features/ProcessView/parts/HeatingElement.vue
+++ b/src/plugins/spark/features/ProcessView/parts/HeatingElement.vue
@@ -1,7 +1,6 @@
 <script lang="ts">
 import Component from 'vue-class-component';
 import PartComponent from '../components/PartComponent';
-import { SQUARE_SIZE } from '../getters';
 import { blocks } from '@/plugins/spark/store/getters';
 import get from 'lodash/get';
 import { Link } from '@/helpers/units';
@@ -17,10 +16,6 @@ export default class HeatingElement extends PartComponent {
         'M50,24.7h24c7.1,0,6.6-6.7,14-6.7h126.9c0,0,7,0.1,7,7c0,7-7,7-7,7H90',
       ],
     };
-  }
-
-  get textTransformation() {
-    return `rotate(${-this.part.rotate},${SQUARE_SIZE / 2},${SQUARE_SIZE / 2})`;
   }
 
   get blockServiceId(): string {
@@ -47,7 +42,11 @@ export default class HeatingElement extends PartComponent {
 
 <template>
   <g class="heating-element">
-    <foreignObject :transform="textTransformation" :width="SQUARE_SIZE" :height="SQUARE_SIZE">
+    <foreignObject
+      :transform="textTransformation([1,1])"
+      :width="SQUARE_SIZE"
+      :height="SQUARE_SIZE"
+    >
       <div class="text-white text-bold text-center">
         <span>%</span>
         <q-icon v-if="!blockLink" name="mdi-link-variant-off"/>

--- a/src/plugins/spark/features/ProcessView/parts/SensorDisplay.vue
+++ b/src/plugins/spark/features/ProcessView/parts/SensorDisplay.vue
@@ -4,15 +4,10 @@ import PartComponent from '../components/PartComponent';
 import { Link } from '@/helpers/units';
 import { blocks } from '@/plugins/spark/store/getters';
 import get from 'lodash/get';
-import { SQUARE_SIZE } from '../getters';
 
 
 @Component
 export default class SensorDisplay extends PartComponent {
-  get textTransformation() {
-    return `rotate(${-this.part.rotate},${SQUARE_SIZE / 2},${SQUARE_SIZE / 2})`;
-  }
-
   get sensorServiceId(): string {
     return this.part.settings.sensorServiceId;
   }
@@ -36,7 +31,11 @@ export default class SensorDisplay extends PartComponent {
 
 <template>
   <g class="sensor-display">
-    <foreignObject :transform="textTransformation" :width="SQUARE_SIZE" :height="SQUARE_SIZE">
+    <foreignObject
+      :transform="textTransformation([1,1])"
+      :width="SQUARE_SIZE"
+      :height="SQUARE_SIZE"
+    >
       <div class="text-white text-bold text-center">
         <q-icon name="mdi-thermometer"/>
         <q-icon v-if="!sensorLink" name="mdi-link-variant-off"/>


### PR DESCRIPTION
Resolves #489 

Parts are always flipped in the orientation that's horizontal at 0 rotation.
During calculation, parts are first flipped, and then rotated.

Text components are unflipped in the same way as they are unrotated.

Added the Flip tool to Process View form.