### PR TITLE
allow using DS2413/mock actuators in brewpi wizard

### DIFF
--- a/src/plugins/spark/arrangements/BrewPi/BrewPiHardwareTask.vue
+++ b/src/plugins/spark/arrangements/BrewPi/BrewPiHardwareTask.vue
@@ -3,7 +3,9 @@ import Component from 'vue-class-component';
 import WizardTaskBase from '@/components/Wizard/WizardTaskBase';
 import { blockValues } from '@/plugins/spark/store/getters';
 import { BrewPiConfig } from '@/plugins/spark/arrangements/BrewPi/state';
-import { typeName as pinType } from '@/plugins/spark/features/ActuatorPin/getters';
+import { typeName as actuatorPinType } from '@/plugins/spark/features/ActuatorPin/getters';
+import { typeName as actuatorDS2413Type } from '@/plugins/spark/features/ActuatorDS2413/getters';
+import { typeName as actuatorMockType } from '@/plugins/spark/features/ActuatorAnalogMock/getters';
 import { typeName as sensorOneWireType } from '@/plugins/spark/features/TempSensorOneWire/getters';
 import { typeName as sensorMockType } from '@/plugins/spark/features/TempSensorMock/getters';
 import { fetchDiscoveredBlocks } from '@/plugins/spark/store/actions';
@@ -11,6 +13,8 @@ import { fetchDiscoveredBlocks } from '@/plugins/spark/store/actions';
 
 @Component
 export default class BrewPiHardwareTask extends WizardTaskBase {
+  blockWizardModalOpen: boolean = false;
+
   coolPin: any = null;
   heatPin: any = null;
   fridgeSensor: any = null;
@@ -21,8 +25,9 @@ export default class BrewPiHardwareTask extends WizardTaskBase {
   }
 
   get pinOptions() {
+    const pinTypes = [actuatorPinType, actuatorDS2413Type, actuatorMockType];
     return blockValues(this.$store, this.cfg.serviceId)
-      .filter(block => block.type === pinType)
+      .filter(block => pinTypes.includes(block.type))
       .map(block => block.id);
   }
 
@@ -86,12 +91,41 @@ export default class BrewPiHardwareTask extends WizardTaskBase {
 
 <template>
   <div>
+    <q-dialog v-model="blockWizardModalOpen" no-backdrop-dismiss>
+      <BlockWizard
+        v-if="blockWizardModalOpen"
+        :service-id="cfg.serviceId"
+        @close="blockWizardModalOpen = false"
+      />
+    </q-dialog>
     <q-card-section>
       <q-item>
         <big>Hardware Blocks</big>
       </q-item>
       <q-item dark>
-        <q-btn label="Discover sensors" color="primary" @click="discover"/>
+        <q-item-section class="col-auto">
+          <q-btn unelevated label="Discover OneWire objects" color="primary" @click="discover"/>
+          <q-tooltip>
+            OneWire temperature sensors and DS2413 chips can be discovered:
+            the Block will be created automatically.
+          </q-tooltip>
+        </q-item-section>
+        <q-item-section class="col-auto">
+          <q-btn
+            unelevated
+            label="Create block"
+            color="primary"
+            @click="blockWizardModalOpen = true"
+          />
+          <q-tooltip>
+            Example cases where a Block must be created and configured manually:
+            <ul>
+              <li>When using DS2413 actuators.</li>
+              <li>When using mock actuators.</li>
+              <li>When using mock temperature sensors.</li>
+            </ul>
+          </q-tooltip>
+        </q-item-section>
       </q-item>
       <q-item dark>
         <q-item-section>

--- a/src/plugins/spark/arrangements/BrewPi/BrewPiHardwareTask.vue
+++ b/src/plugins/spark/arrangements/BrewPi/BrewPiHardwareTask.vue
@@ -5,7 +5,6 @@ import { blockValues } from '@/plugins/spark/store/getters';
 import { BrewPiConfig } from '@/plugins/spark/arrangements/BrewPi/state';
 import { typeName as actuatorPinType } from '@/plugins/spark/features/ActuatorPin/getters';
 import { typeName as actuatorDS2413Type } from '@/plugins/spark/features/ActuatorDS2413/getters';
-import { typeName as actuatorMockType } from '@/plugins/spark/features/ActuatorAnalogMock/getters';
 import { typeName as sensorOneWireType } from '@/plugins/spark/features/TempSensorOneWire/getters';
 import { typeName as sensorMockType } from '@/plugins/spark/features/TempSensorMock/getters';
 import { fetchDiscoveredBlocks } from '@/plugins/spark/store/actions';
@@ -25,7 +24,7 @@ export default class BrewPiHardwareTask extends WizardTaskBase {
   }
 
   get pinOptions() {
-    const pinTypes = [actuatorPinType, actuatorDS2413Type, actuatorMockType];
+    const pinTypes = [actuatorPinType, actuatorDS2413Type];
     return blockValues(this.$store, this.cfg.serviceId)
       .filter(block => pinTypes.includes(block.type))
       .map(block => block.id);
@@ -121,7 +120,6 @@ export default class BrewPiHardwareTask extends WizardTaskBase {
             Example cases where a Block must be created and configured manually:
             <ul>
               <li>When using DS2413 actuators.</li>
-              <li>When using mock actuators.</li>
               <li>When using mock temperature sensors.</li>
             </ul>
           </q-tooltip>

--- a/src/plugins/spark/arrangements/BrewPi/BrewPiSettingsTask.vue
+++ b/src/plugins/spark/arrangements/BrewPi/BrewPiSettingsTask.vue
@@ -31,6 +31,15 @@ export default class BrewPiSettingsTask extends WizardTaskBase {
     return this.stagedConfig;
   }
 
+  blockType(newId: string): string {
+    for (let [from, to] of Object.entries(this.cfg.renamedBlocks)) {
+      if (to === newId) {
+        return blockById(this.$store, this.cfg.serviceId, from).type;
+      }
+    }
+    throw new Error('Old block not found');
+  }
+
   defineCreatedBlocks() {
     this.cfg.createdBlocks = [
       // setpoint sensor pair
@@ -180,7 +189,7 @@ export default class BrewPiSettingsTask extends WizardTaskBase {
       {
         id: this.cfg.names.coolPin,
         serviceId: this.cfg.serviceId,
-        type: pinType,
+        type: this.blockType(this.cfg.names.coolPin),
         groups: this.cfg.groups,
         data: {
           constrainedBy: {
@@ -195,7 +204,7 @@ export default class BrewPiSettingsTask extends WizardTaskBase {
       {
         id: this.cfg.names.heatPin,
         serviceId: this.cfg.serviceId,
-        type: pinType,
+        type: this.blockType(this.cfg.names.heatPin),
         groups: this.cfg.groups,
         data: {
           constrainedBy: {
@@ -208,15 +217,6 @@ export default class BrewPiSettingsTask extends WizardTaskBase {
     ];
   }
 
-  sensorType(newId: string): string {
-    for (let [from, to] of Object.entries(this.cfg.renamedBlocks)) {
-      if (to === newId) {
-        return blockById(this.$store, this.cfg.serviceId, from).type;
-      }
-    }
-    throw new Error('Old sensor not found');
-  }
-
   defineWidgets() {
     const genericSettings = {
       dashboard: this.cfg.dashboardId,
@@ -225,9 +225,11 @@ export default class BrewPiSettingsTask extends WizardTaskBase {
       order: 0,
     };
 
-    const sensorTypes = {
-      fridge: this.sensorType(this.cfg.names.fridgeSensor),
-      beer: this.sensorType(this.cfg.names.beerSensor),
+    const variableTypes = {
+      fridge: this.blockType(this.cfg.names.fridgeSensor),
+      beer: this.blockType(this.cfg.names.beerSensor),
+      coolPin: this.blockType(this.cfg.names.coolPin),
+      heatPin: this.blockType(this.cfg.names.heatPin),
     };
 
     const createWidget =
@@ -251,12 +253,12 @@ export default class BrewPiSettingsTask extends WizardTaskBase {
       // Setpoint profile
       createWidget(this.cfg.names.tempProfile, spProfileType),
       // Sensors
-      createWidget(this.cfg.names.fridgeSensor, sensorTypes.fridge),
-      createWidget(this.cfg.names.beerSensor, sensorTypes.beer),
+      createWidget(this.cfg.names.fridgeSensor, variableTypes.fridge),
+      createWidget(this.cfg.names.beerSensor, variableTypes.beer),
       // SSPairs are skipped
       // Pins
-      createWidget(this.cfg.names.coolPin, pinType),
-      createWidget(this.cfg.names.heatPin, pinType),
+      createWidget(this.cfg.names.coolPin, variableTypes.coolPin),
+      createWidget(this.cfg.names.heatPin, variableTypes.heatPin),
       // PWMs
       createWidget(this.cfg.names.coolPwm, pwmType),
       createWidget(this.cfg.names.heatPwm, pwmType),


### PR DESCRIPTION
Resolves #538 

The following types can now be used as fermentation actuator:
- ActuatorDS2413
- ActuatorPin

Adds a "create block" button in the fermentation wizard. This allows creating mock blocks and indirect actuators (ActuatorDS2413) without leaving the arrangement wizard.