### PR TITLE
use window offset when calculating clicked square

### DIFF
--- a/src/plugins/spark/features/ProcessView/ProcessViewForm.vue
+++ b/src/plugins/spark/features/ProcessView/ProcessViewForm.vue
@@ -181,7 +181,6 @@ export default class ProcessViewForm extends FormBase {
         cursor: part => !!part,
         onClick: (evt, part) => this.removePart(part),
       },
-      // TODO: flip part
     ];
   }
 
@@ -218,6 +217,8 @@ export default class ProcessViewForm extends FormBase {
   }
 
   findGridSquare(grid: Rect, x: number, y: number) {
+    x -= window.pageXOffset;
+    y -= window.pageYOffset;
     if (!this.rectContains(grid, x, y)) {
       return null;
     }


### PR DESCRIPTION
Resolves #549 

Window click events are offset from the page origin, not the displayed origin. This is true even in fullscreen quasar dialog modals.

If the user scrolls 100px down, opens the modal, and then clicks on what looks to him like (50,100), the click event is reported at (50,200).