### PR TITLE
Performance improvements in flow calculation

### DIFF
--- a/src/plugins/builder/calculateFlows.ts
+++ b/src/plugins/builder/calculateFlows.ts
@@ -8,7 +8,6 @@ import get from 'lodash/get';
 import has from 'lodash/has';
 import mapKeys from 'lodash/mapKeys';
 import mapValues from 'lodash/mapValues';
-import cloneDeep from 'lodash/cloneDeep';
 import pickBy from 'lodash/pickBy';
 import set from 'lodash/set';
 
@@ -173,7 +172,8 @@ export const flowPath = (
   const outFlows: FlowRoute[] = get(start, ['transitions', inCoord], []);
   const path = new FlowSegment(start, {});
 
-  let candidateParts: FlowPart[] = cloneDeep(parts);
+  let candidateParts: FlowPart[] = parts.map(part =>
+    ({ ...part, transitions: { ...part.transitions } }));
 
   candidateParts.forEach((p: FlowPart) => {
     delete p.transitions[inCoord];
@@ -284,7 +284,7 @@ export const addFlowForSegment = (
 
 const addFlowFromPart = (parts, part): FlowPart[] => {
   for (let inCoords in part.transitions) {
-    const outFlows = part.transitions[inCoords];
+    const outFlows = part.transitions[inCoords] || [];
     for (let outFlow of outFlows) {
       const pressure: number = outFlow.pressure || 0;
       const liquids: string[] | undefined = outFlow.liquids;

--- a/src/plugins/builder/calculateFlows.ts
+++ b/src/plugins/builder/calculateFlows.ts
@@ -172,12 +172,13 @@ export const flowPath = (
   const outFlows: FlowRoute[] = get(start, ['transitions', inCoord], []);
   const path = new FlowSegment(start, {});
 
-  let candidateParts: FlowPart[] = parts.map(part =>
-    ({ ...part, transitions: { ...part.transitions } }));
-
-  candidateParts.forEach((p: FlowPart) => {
-    delete p.transitions[inCoord];
-  });
+  let candidateParts: FlowPart[] = parts.reduce((acc: FlowPart[], part: FlowPart) => {
+    const { [inCoord]: _, ...filteredTransitions } = part.transitions; // make a copy of transitions excluding inCoord
+    if (Object.getOwnPropertyNames(filteredTransitions).length !== 0) { // exclude parts without transitions
+      acc.push({ ...part, transitions: filteredTransitions });
+    }
+    return acc;
+  }, []);
 
   for (let outFlow of outFlows) {
     while (true) {


### PR DESCRIPTION
Do not merge yet. WIP

Remove anti-patterns causing unnecessary deep object copies, mainly by using a reducer to create a new object:

let result = items.reduce((acc, item) => ({
   ...acc, [item.name]: item.value
}), {})

This creates a new copy of the accumulator for each object!