### PR TITLE
implement loading/saving user profiles

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
 import Vue from 'vue';
 import { Component } from 'vue-property-decorator';
 
+import { sparkStore } from '@/plugins/spark/store';
 import { dashboardStore } from '@/store/dashboards';
 import { serviceStore } from '@/store/services';
 
@@ -11,6 +12,7 @@ export default class App extends Vue {
     await Promise.all([
       serviceStore.setup(),
       dashboardStore.setup(),
+      sparkStore.setup(),
     ]);
   }
 }

--- a/src/helpers/database-api.ts
+++ b/src/helpers/database-api.ts
@@ -1,0 +1,36 @@
+import database, { StoreObject } from '@/plugins/database';
+
+type ChangeCallback = (doc: any) => void;
+type DeleteCallback = (id: string) => void;
+
+export type DatabaseApi<T> = {
+  setup(onChanged: ChangeCallback, onDeleted: DeleteCallback): void;
+  fetch(): Promise<T[]>;
+  fetchById(id: string): Promise<T>;
+  create(val: T): Promise<T>;
+  persist(val: T): Promise<T>;
+  remove(val: T): Promise<T>;
+}
+
+export function generate<T extends StoreObject>(moduleId: string): DatabaseApi<T> {
+  return {
+    setup(onChanged: ChangeCallback, onDeleted: DeleteCallback): void {
+      database.registerModule({ id: moduleId, onChanged, onDeleted });
+    },
+    async fetch(): Promise<T[]> {
+      return database.fetchAll(moduleId);
+    },
+    async fetchById(id: string): Promise<T> {
+      return database.fetchById(moduleId, id);
+    },
+    async create(val: T): Promise<T> {
+      return database.create(moduleId, val);
+    },
+    async persist(val: T): Promise<T> {
+      return database.persist(moduleId, val);
+    },
+    async remove(val: T): Promise<T> {
+      return database.remove(moduleId, val);
+    },
+  };
+}

--- a/src/plugins/builder/store/api.ts
+++ b/src/plugins/builder/store/api.ts
@@ -1,24 +1,7 @@
-import database from '@/plugins/database';
+import { generate } from '@/helpers/database-api';
 
 import { BuilderLayout } from '../types';
 
-const LAYOUTS = 'layouts';
+const api = generate<BuilderLayout>('layouts');
 
-export const setup =
-  (onChanged: (doc: any) => void, onDeleted: (id: string) => void, ): void =>
-    database.registerModule({ onChanged, onDeleted, id: LAYOUTS });
-
-export const fetchLayouts = async (): Promise<BuilderLayout[]> =>
-  database.fetchAll(LAYOUTS);
-
-export const fetchLayoutById = async (id: string): Promise<BuilderLayout> =>
-  database.fetchById(LAYOUTS, id);
-
-export const createLayout = async (layout: BuilderLayout): Promise<BuilderLayout> =>
-  database.create(LAYOUTS, layout);
-
-export const persistLayout = async (layout: BuilderLayout): Promise<BuilderLayout> =>
-  database.persist(LAYOUTS, layout);
-
-export const deleteLayout = async (layout: BuilderLayout): Promise<BuilderLayout> =>
-  database.remove(LAYOUTS, layout);
+export default api;

--- a/src/plugins/builder/store/index.ts
+++ b/src/plugins/builder/store/index.ts
@@ -5,13 +5,7 @@ import { objReducer } from '@/helpers/functional';
 import store from '@/store';
 
 import { BuilderLayout, PartSpec } from '../types';
-import {
-  createLayout as createLayoutInApi,
-  deleteLayout as removeLayoutInApi,
-  fetchLayouts as fetchLayoutsInApi,
-  persistLayout as persistLayoutInApi,
-  setup as setupInApi,
-} from './api';
+import api from './api';
 
 const rawError = true;
 
@@ -85,24 +79,23 @@ export class BuilderModule extends VuexModule {
 
   @Action({ rawError })
   public async createLayout(layout: BuilderLayout): Promise<void> {
-    this.commitLayout(await createLayoutInApi(layout));
+    this.commitLayout(await api.create(layout));
   }
 
   @Action({ rawError })
   public async saveLayout(layout: BuilderLayout): Promise<void> {
-    this.commitLayout(await persistLayoutInApi(layout));
+    this.commitLayout(await api.persist(layout));
   }
 
   @Action({ rawError })
   public async removeLayout(layout: BuilderLayout): Promise<void> {
-    await removeLayoutInApi(layout)
+    await api.remove(layout)
       .catch(() => { });
     this.commitRemoveLayout(layout);
   }
 
   @Action({ rawError })
   public async setup(): Promise<void> {
-    /* eslint-disable no-underscore-dangle */
     const onChange = async (layout: BuilderLayout): Promise<void> => {
       const existing = this.layoutById(layout.id);
       if (!existing || existing._rev !== layout._rev) {
@@ -115,10 +108,9 @@ export class BuilderModule extends VuexModule {
         this.removeLayout(existing);
       }
     };
-    /* eslint-enable no-underscore-dangle */
 
-    this.commitAllLayouts(await fetchLayoutsInApi());
-    setupInApi(onChange, onDelete);
+    this.commitAllLayouts(await api.fetch());
+    api.setup(onChange, onDelete);
   }
 }
 

--- a/src/plugins/spark/features/ActuatorAnalogMock/getters.ts
+++ b/src/plugins/spark/features/ActuatorAnalogMock/getters.ts
@@ -1,9 +1,1 @@
-import { sparkStore } from '@/plugins/spark/store';
-
-import { ActuatorAnalogMockBlock } from './types';
-
 export const typeName = 'ActuatorAnalogMock';
-
-export const getById =
-  (serviceId: string, id: string): ActuatorAnalogMockBlock =>
-    sparkStore.blockById(serviceId, id, typeName);

--- a/src/plugins/spark/features/ActuatorOffset/getters.ts
+++ b/src/plugins/spark/features/ActuatorOffset/getters.ts
@@ -1,9 +1,1 @@
-import { sparkStore } from '@/plugins/spark/store';
-
-import { ActuatorOffsetBlock } from './types';
-
 export const typeName = 'ActuatorOffset';
-
-export const getById =
-  (serviceId: string, id: string): ActuatorOffsetBlock =>
-    sparkStore.blockById(serviceId, id, typeName);

--- a/src/plugins/spark/features/ActuatorPwm/getters.ts
+++ b/src/plugins/spark/features/ActuatorPwm/getters.ts
@@ -1,9 +1,1 @@
-import { sparkStore } from '@/plugins/spark/store';
-
-import { ActuatorPwmBlock } from './types';
-
 export const typeName = 'ActuatorPwm';
-
-export const getById =
-  (serviceId: string, id: string): ActuatorPwmBlock =>
-    sparkStore.blockById(serviceId, id, typeName);

--- a/src/plugins/spark/features/Balancer/getters.ts
+++ b/src/plugins/spark/features/Balancer/getters.ts
@@ -2,13 +2,7 @@ import get from 'lodash/get';
 
 import { sparkStore } from '@/plugins/spark/store';
 
-import { BalancerBlock } from './types';
-
 export const typeName = 'Balancer';
-
-export const getById =
-  (serviceId: string, id: string): BalancerBlock =>
-    sparkStore.blockById(serviceId, id, typeName);
 
 export const getClients =
   (serviceId: string, balancerId: string): { [balanceId: string]: string } =>

--- a/src/plugins/spark/features/DS2413/getters.ts
+++ b/src/plugins/spark/features/DS2413/getters.ts
@@ -1,9 +1,1 @@
-import { sparkStore } from '@/plugins/spark/store';
-
-import { DS2413Block } from './types';
-
 export const typeName = 'DS2413';
-
-export const getById =
-  (serviceId: string, id: string): DS2413Block =>
-    sparkStore.blockById(serviceId, id, typeName);

--- a/src/plugins/spark/features/DisplaySettings/getters.ts
+++ b/src/plugins/spark/features/DisplaySettings/getters.ts
@@ -1,7 +1,3 @@
-import { sparkStore } from '@/plugins/spark/store';
-
-import { DisplaySettingsBlock } from './types';
-
 export const typeName = 'DisplaySettings';
 
 export const validDisplayTypes = [
@@ -12,7 +8,3 @@ export const validDisplayTypes = [
   'ActuatorAnalogMock',
   'Pid',
 ];
-
-export const getById =
-  (serviceId: string, id: string): DisplaySettingsBlock =>
-    sparkStore.blockById(serviceId, id, typeName);

--- a/src/plugins/spark/features/InactiveObject/getters.ts
+++ b/src/plugins/spark/features/InactiveObject/getters.ts
@@ -1,9 +1,1 @@
-import { sparkStore } from '@/plugins/spark/store';
-
-import { InactiveObjectBlock } from './types';
-
 export const typeName = 'InactiveObject';
-
-export const getById =
-  (serviceId: string, id: string): InactiveObjectBlock =>
-    sparkStore.blockById(serviceId, id, typeName);

--- a/src/plugins/spark/features/MotorValve/MotorValveWidget.vue
+++ b/src/plugins/spark/features/MotorValve/MotorValveWidget.vue
@@ -17,18 +17,20 @@ export default class MotorValveWidget extends BlockWidget {
     return spaceCased(ValveState[this.block.data.valveState]);
   }
 
-  get disabled12V(): boolean {
-    const pins: Spark3PinsBlock | undefined = sparkStore.blockValues(this.serviceId)
+  get pins(): Spark3PinsBlock | null {
+    const block = sparkStore.blockValues(this.serviceId)
       .find(block => block.type === spark3PinType);
-    return !!pins && !pins.data.enableIoSupply12V;
+    return block ? block as Spark3PinsBlock : null;
+  }
+
+  get disabled12V(): boolean {
+    return !!this.pins && !this.pins.data.enableIoSupply12V;
   }
 
   enable12V(): void {
-    const pins: Spark3PinsBlock | undefined = sparkStore.blockValues(this.serviceId)
-      .find(block => block.type === spark3PinType);
-    if (pins) {
-      pins.data.enableIoSupply12V = true;
-      sparkStore.saveBlock([this.serviceId, pins]);
+    if (this.pins) {
+      this.pins.data.enableIoSupply12V = true;
+      sparkStore.saveBlock([this.serviceId, this.pins]);
     }
   }
 }

--- a/src/plugins/spark/features/Mutex/getters.ts
+++ b/src/plugins/spark/features/Mutex/getters.ts
@@ -3,13 +3,7 @@ import get from 'lodash/get';
 import { sparkStore } from '@/plugins/spark/store';
 import { Block } from '@/plugins/spark/types';
 
-import { MutexBlock } from './types';
-
 export const typeName = 'Mutex';
-
-export const getById =
-  (serviceId: string, id: string): MutexBlock =>
-    sparkStore.blockById(serviceId, id, typeName);
 
 export interface MutexBlocks {
   active: string[];

--- a/src/plugins/spark/features/Pid/getters.ts
+++ b/src/plugins/spark/features/Pid/getters.ts
@@ -1,9 +1,1 @@
-import { sparkStore } from '@/plugins/spark/store';
-
-import { PidBlock } from './types';
-
 export const typeName = 'Pid';
-
-export const getById =
-  (serviceId: string, id: string): PidBlock =>
-    sparkStore.blockById(serviceId, id, typeName);

--- a/src/plugins/spark/features/SetpointProfile/ProfilePresetAction.vue
+++ b/src/plugins/spark/features/SetpointProfile/ProfilePresetAction.vue
@@ -1,0 +1,36 @@
+<script lang="ts">
+import { Component, Prop } from 'vue-property-decorator';
+
+import { createDialog } from '@/helpers/dialog';
+
+import BlockCrudComponent from '../../components/BlockCrudComponent';
+import ProfilePresetDialog from './ProfilePresetDialog.vue';
+
+
+@Component({
+  components: {
+    ProfilePresetDialog,
+  },
+})
+export default class ProfilePresetAction extends BlockCrudComponent {
+
+  @Prop({ type: String, default: 'mdi-file' })
+  readonly icon!: string;
+
+  @Prop({ type: String, default: 'Load/Save Profile' })
+  readonly label!: string;
+
+  async showDialog(): Promise<void> {
+    createDialog({
+      component: ProfilePresetDialog,
+      value: this.block,
+      root: this.$root,
+      title: 'Load/Save Profile',
+    });
+  }
+}
+</script>
+
+<template>
+  <ActionItem v-bind="{...$attrs, ...$props}" @click="showDialog" />
+</template>

--- a/src/plugins/spark/features/SetpointProfile/ProfilePresetAction.vue
+++ b/src/plugins/spark/features/SetpointProfile/ProfilePresetAction.vue
@@ -4,14 +4,9 @@ import { Component, Prop } from 'vue-property-decorator';
 import { createDialog } from '@/helpers/dialog';
 
 import BlockCrudComponent from '../../components/BlockCrudComponent';
-import ProfilePresetDialog from './ProfilePresetDialog.vue';
 
 
-@Component({
-  components: {
-    ProfilePresetDialog,
-  },
-})
+@Component
 export default class ProfilePresetAction extends BlockCrudComponent {
 
   @Prop({ type: String, default: 'mdi-file' })
@@ -22,7 +17,7 @@ export default class ProfilePresetAction extends BlockCrudComponent {
 
   async showDialog(): Promise<void> {
     createDialog({
-      component: ProfilePresetDialog,
+      component: 'ProfilePresetDialog',
       value: this.block,
       root: this.$root,
       title: 'Load/Save Profile',

--- a/src/plugins/spark/features/SetpointProfile/ProfilePresetDialog.vue
+++ b/src/plugins/spark/features/SetpointProfile/ProfilePresetDialog.vue
@@ -1,0 +1,153 @@
+<script lang="ts">
+import cloneDeep from 'lodash/cloneDeep';
+import { uid } from 'quasar';
+import { Component, Prop } from 'vue-property-decorator';
+
+import DialogBase from '@/components/Dialog/DialogBase';
+import { createDialog } from '@/helpers/dialog';
+import { deserialize, serialize } from '@/helpers/units/parseObject';
+import { sparkStore } from '@/plugins/spark/store';
+
+import { typeName } from './getters';
+import { SetpointProfileBlock } from './types';
+
+@Component
+export default class ProfilePresetDialog extends DialogBase {
+  selected: SelectOption | null = null;
+
+  @Prop({ type: Object })
+  public readonly value!: SetpointProfileBlock;
+
+  get options(): SelectOption[] {
+    return sparkStore.presetValues
+      .filter(preset => preset.type === typeName)
+      .map(preset => ({ label: preset.name, value: preset.id }));
+  }
+
+  removeSelected(): void {
+    if (this.selected === null) {
+      return;
+    }
+    const preset = sparkStore.presets[this.selected.value];
+    this.selected = null;
+    sparkStore.removePreset(preset);
+  }
+
+  editSelected(): void {
+    if (this.selected === null) {
+      return;
+    }
+    const preset = sparkStore.presets[this.selected.value];
+    createDialog({
+      title: 'Edit profile name',
+      dark: true,
+      cancel: true,
+      prompt: {
+        model: preset.name,
+        type: 'text',
+      },
+    })
+      .onOk(name => sparkStore.savePreset({ ...preset, name }));
+  }
+
+  async loadSelected(): Promise<void> {
+    if (this.selected === null) {
+      return;
+    }
+    const preset = sparkStore.presets[this.selected.value];
+    this.value.data.points = deserialize(cloneDeep(preset.data.points));
+    await sparkStore.saveBlock([this.value.serviceId, this.value]);
+    this.onDialogOk();
+  }
+
+  async saveSelected(): Promise<void> {
+    if (this.selected === null) {
+      return;
+    }
+    const preset = sparkStore.presets[this.selected.value];
+    preset.data = {
+      points: cloneDeep(serialize(this.value.data.points)),
+    };
+    await sparkStore.savePreset(preset);
+    this.onDialogOk();
+  }
+
+  createPreset(): void {
+    createDialog({
+      title: 'Save as new profile',
+      dark: true,
+      cancel: true,
+      prompt: {
+        model: `${this.value.id} profile`,
+        type: 'text',
+      },
+    })
+      .onOk(async name => {
+        await sparkStore.createPreset({
+          id: uid(),
+          name,
+          type: typeName,
+          data: {
+            points: cloneDeep(serialize(this.value.data.points)),
+          },
+        });
+        this.onDialogOk();
+      });
+  }
+}
+</script>
+
+<template>
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+  >
+    <q-card class="q-dialog-plugin q-dialog-plugin--dark" dark>
+      <q-card-section class="q-dialog__title">
+        {{ title }}
+      </q-card-section>
+      <q-card-section v-if="message" class="q-dialog__message scroll">
+        {{ message }}
+      </q-card-section>
+      <q-card-section v-if="messageHtml" class="q-dialog__message scroll" v-html="messageHtml" />
+      <q-card-section class="scroll">
+        <q-item dark>
+          <q-item-section>
+            <q-select
+              v-model="selected"
+              :options="options"
+              label="Profiles"
+              dark
+              autofocus
+              options-dark
+            >
+              <template v-slot:no-option>
+                <q-item dark>
+                  <q-item-section class="text-grey">
+                    No results
+                  </q-item-section>
+                </q-item>
+              </template>
+              <template v-if="!!selected" v-slot:after>
+                <q-btn flat round icon="edit" @click="editSelected">
+                  <q-tooltip>Rename profile</q-tooltip>
+                </q-btn>
+                <q-btn flat round icon="delete" @click="removeSelected">
+                  <q-tooltip>Remove profile</q-tooltip>
+                </q-btn>
+              </template>
+            </q-select>
+          </q-item-section>
+        </q-item>
+      </q-card-section>
+      <q-card-actions align="right">
+        <q-btn flat label="Cancel" @click="onDialogCancel" />
+        <q-space />
+        <q-btn :disable="!selected" color="primary" flat label="load" @click="loadSelected" />
+        <q-btn :disable="!selected" color="primary" flat label="save" @click="saveSelected" />
+        <q-btn color="primary" flat label="New" @click="createPreset" />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>

--- a/src/plugins/spark/features/SetpointProfile/ProfilePresetDialog.vue
+++ b/src/plugins/spark/features/SetpointProfile/ProfilePresetDialog.vue
@@ -55,9 +55,26 @@ export default class ProfilePresetDialog extends DialogBase {
       return;
     }
     const preset = sparkStore.presets[this.selected.value];
-    this.value.data.points = deserialize(cloneDeep(preset.data.points));
-    await sparkStore.saveBlock([this.value.serviceId, this.value]);
-    this.onDialogOk();
+    const points = deserialize(cloneDeep(preset.data.points));
+
+    createDialog({
+      title: 'Profile start',
+      message: `Do you want to change '${this.value.id}' start time to now?`,
+      dark: true,
+      ok: 'Yes',
+      cancel: 'No',
+    })
+      .onOk(async () => {
+        this.value.data.start = new Date().getTime() / 1000;
+        this.value.data.points = points;
+        await sparkStore.saveBlock([this.value.serviceId, this.value]);
+        this.onDialogOk();
+      })
+      .onCancel(async () => {
+        this.value.data.points = points;
+        await sparkStore.saveBlock([this.value.serviceId, this.value]);
+        this.onDialogOk();
+      });
   }
 
   async saveSelected(): Promise<void> {

--- a/src/plugins/spark/features/SetpointProfile/SetpointProfileForm.vue
+++ b/src/plugins/spark/features/SetpointProfile/SetpointProfileForm.vue
@@ -9,6 +9,7 @@ import BlockCrudComponent from '@/plugins/spark/components/BlockCrudComponent';
 import { sparkStore } from '@/plugins/spark/store';
 
 import { profileGraphProps } from './helpers';
+import ProfilePresetAction from './ProfilePresetAction.vue';
 import { Setpoint, SetpointProfileBlock } from './types';
 
 interface DisplaySetpoint {
@@ -17,7 +18,11 @@ interface DisplaySetpoint {
   temperature: Unit;
 }
 
-@Component
+@Component({
+  components: {
+    ProfilePresetAction,
+  },
+})
 export default class SetpointProfileForm extends BlockCrudComponent {
   durationString = durationString;
   parseDuration = parseDuration;
@@ -169,7 +174,11 @@ export default class SetpointProfileForm extends BlockCrudComponent {
     </template>
 
     <q-card dark class="widget-modal">
-      <BlockFormToolbar :crud="crud" />
+      <BlockFormToolbar :crud="crud">
+        <template v-slot:actions>
+          <ProfilePresetAction :crud="crud" />
+        </template>
+      </BlockFormToolbar>
       <q-card-section>
         <BlockEnableToggle
           v-if="block.data.targetId.id !== null"

--- a/src/plugins/spark/features/SetpointProfile/SetpointProfileForm.vue
+++ b/src/plugins/spark/features/SetpointProfile/SetpointProfileForm.vue
@@ -9,7 +9,6 @@ import BlockCrudComponent from '@/plugins/spark/components/BlockCrudComponent';
 import { sparkStore } from '@/plugins/spark/store';
 
 import { profileGraphProps } from './helpers';
-import ProfilePresetAction from './ProfilePresetAction.vue';
 import { Setpoint, SetpointProfileBlock } from './types';
 
 interface DisplaySetpoint {
@@ -18,11 +17,7 @@ interface DisplaySetpoint {
   temperature: Unit;
 }
 
-@Component({
-  components: {
-    ProfilePresetAction,
-  },
-})
+@Component
 export default class SetpointProfileForm extends BlockCrudComponent {
   durationString = durationString;
   parseDuration = parseDuration;

--- a/src/plugins/spark/features/SetpointProfile/SetpointProfileWidget.vue
+++ b/src/plugins/spark/features/SetpointProfile/SetpointProfileWidget.vue
@@ -4,9 +4,14 @@ import { Component } from 'vue-property-decorator';
 import BlockWidget from '@/plugins/spark/components/BlockWidget';
 
 import { GraphProps, profileGraphProps } from './helpers';
+import ProfilePresetAction from './ProfilePresetAction.vue';
 import { SetpointProfileBlock } from './types';
 
-@Component
+@Component({
+  components: {
+    ProfilePresetAction,
+  },
+})
 export default class SetpointProfileWidget extends BlockWidget {
   readonly block!: SetpointProfileBlock;
   revision = 0;
@@ -28,7 +33,11 @@ export default class SetpointProfileWidget extends BlockWidget {
 
 <template>
   <q-card dark class="text-white column">
-    <BlockWidgetToolbar :crud="crud" />
+    <BlockWidgetToolbar :crud="crud">
+      <template v-slot:actions>
+        <ProfilePresetAction :crud="crud" />
+      </template>
+    </BlockWidgetToolbar>
     <CardWarning v-if="!block.data.targetId.id">
       <template #message>
         Setpoint Profile has no target Setpoint configured.

--- a/src/plugins/spark/features/SetpointProfile/SetpointProfileWidget.vue
+++ b/src/plugins/spark/features/SetpointProfile/SetpointProfileWidget.vue
@@ -4,14 +4,9 @@ import { Component } from 'vue-property-decorator';
 import BlockWidget from '@/plugins/spark/components/BlockWidget';
 
 import { GraphProps, profileGraphProps } from './helpers';
-import ProfilePresetAction from './ProfilePresetAction.vue';
 import { SetpointProfileBlock } from './types';
 
-@Component({
-  components: {
-    ProfilePresetAction,
-  },
-})
+@Component
 export default class SetpointProfileWidget extends BlockWidget {
   readonly block!: SetpointProfileBlock;
   revision = 0;

--- a/src/plugins/spark/features/SetpointProfile/getters.ts
+++ b/src/plugins/spark/features/SetpointProfile/getters.ts
@@ -1,9 +1,1 @@
-import { sparkStore } from '@/plugins/spark/store';
-
-import { SetpointProfileBlock } from './types';
-
 export const typeName = 'SetpointProfile';
-
-export const getById =
-  (serviceId: string, id: string): SetpointProfileBlock =>
-    sparkStore.blockById(serviceId, id, typeName);

--- a/src/plugins/spark/features/SetpointProfile/index.ts
+++ b/src/plugins/spark/features/SetpointProfile/index.ts
@@ -6,6 +6,8 @@ import { Feature } from '@/store/features';
 
 import { BlockSpec } from '../../types';
 import { typeName } from './getters';
+import ProfilePresetAction from './ProfilePresetAction.vue';
+import ProfilePresetDialog from './ProfilePresetDialog.vue';
 import form from './SetpointProfileForm.vue';
 import widget from './SetpointProfileWidget.vue';
 import { SetpointProfileData } from './types';
@@ -52,6 +54,9 @@ const block: BlockSpec = {
     },
   ],
 };
+
+ref(ProfilePresetAction);
+ref(ProfilePresetDialog);
 
 const feature: Feature = {
   ...GenericBlock,

--- a/src/plugins/spark/features/SetpointSensorPair/getters.ts
+++ b/src/plugins/spark/features/SetpointSensorPair/getters.ts
@@ -1,9 +1,1 @@
-import { sparkStore } from '@/plugins/spark/store';
-
-import { SetpointSensorPairBlock } from './types';
-
 export const typeName = 'SetpointSensorPair';
-
-export const getById =
-  (serviceId: string, id: string): SetpointSensorPairBlock =>
-    sparkStore.blockById(serviceId, id, typeName);

--- a/src/plugins/spark/features/TempSensorMock/getters.ts
+++ b/src/plugins/spark/features/TempSensorMock/getters.ts
@@ -1,9 +1,1 @@
-import { sparkStore } from '@/plugins/spark/store';
-
-import { TempSensorMockBlock } from './types';
-
 export const typeName = 'TempSensorMock';
-
-export const getById =
-  (serviceId: string, id: string): TempSensorMockBlock =>
-    sparkStore.blockById(serviceId, id, typeName);

--- a/src/plugins/spark/features/TempSensorOneWire/getters.ts
+++ b/src/plugins/spark/features/TempSensorOneWire/getters.ts
@@ -1,9 +1,1 @@
-import { sparkStore } from '@/plugins/spark/store';
-
-import { TempSensorOneWireBlock } from './types';
-
 export const typeName = 'TempSensorOneWire';
-
-export const getById =
-  (serviceId: string, id: string): TempSensorOneWireBlock =>
-    sparkStore.blockById(serviceId, id, typeName);

--- a/src/plugins/spark/store/helpers.ts
+++ b/src/plugins/spark/store/helpers.ts
@@ -1,0 +1,93 @@
+import { Link } from '@/helpers/units';
+
+import { ConstraintsObj } from '../components/Constraints/ConstraintsBase';
+import { constraintLabels } from '../helpers';
+import { Block, BlockLink,Limiters } from '../types';
+
+export const calculateDrivenChains = (blocks: Block[]): string[][] => {
+  const output: string[][] = [];
+
+  const drivenBlocks: { [driven: string]: string[] } = {};
+
+  for (const block of blocks) {
+    Object
+      .values(block.data)
+      .filter((obj: any) => obj instanceof Link && obj.driven && obj.id)
+      .forEach((obj: any) => {
+        const existing = drivenBlocks[obj.id] || [];
+        drivenBlocks[obj.id] = [...existing, block.id];
+      });
+  }
+
+  const generateChains =
+    (chain: string[], latest: string): string[][] => {
+      const additional: string[] = drivenBlocks[latest];
+      if (!additional) {
+        return [[...chain, latest]];
+      }
+      return additional
+        .filter(id => !chain.includes(id))
+        .reduce(
+          (chains: string[][], id: string) => [...chains, ...generateChains([...chain, latest], id)],
+          [],
+        );
+    };
+
+  return Object.keys(drivenBlocks)
+    .reduce((acc, k) => ([...acc, ...generateChains([], k)]), output);
+};
+
+export const calculateBlockLinks = (blocks: Block[]): BlockLink[] => {
+  const linkArray: BlockLink[] = [];
+
+  const findRelations =
+    (source: string, relation: string[], val: any): BlockLink[] => {
+      if (val instanceof Link) {
+        if (val.id === null || source === 'DisplaySettings') {
+          return linkArray;
+        }
+        return [{
+          source: source,
+          target: val.toString(),
+          relation: relation,
+        }];
+      }
+      if (val instanceof Object) {
+        return Object.entries(val)
+          .reduce(
+            (acc, child: Mapped<any>) => {
+              if (child[0].startsWith('driven')) {
+                return acc;
+              }
+              return [...acc, ...findRelations(source, [...relation, child[0]], child[1])];
+            },
+            linkArray
+          );
+      }
+      return linkArray;
+    };
+
+  const allLinks: BlockLink[] = [];
+  for (const block of blocks) {
+    allLinks.push(...findRelations(block.id, [], block.data));
+  }
+
+  return allLinks;
+};
+
+export const calculateLimiters = (blocks: Block[]): Limiters => {
+  const limited: Limiters = {};
+
+  for (const block of blocks) {
+    const obj: ConstraintsObj = block.data.constrainedBy;
+    if (!obj || obj.constraints.length === 0) {
+      continue;
+    }
+    limited[block.id] = [...obj.constraints]
+      .filter(c => c.limiting)
+      .map(c => Object.keys(c).find(key => key !== 'limiting') || '??')
+      .map(k => constraintLabels.get(k) as string);
+  }
+
+  return limited;
+};

--- a/src/plugins/spark/store/index.ts
+++ b/src/plugins/spark/store/index.ts
@@ -3,13 +3,10 @@ import Vue from 'vue';
 import { Action, getModule, Module, Mutation, VuexModule } from 'vuex-module-decorators';
 
 import { objReducer } from '@/helpers/functional';
-import { Link } from '@/helpers/units';
 import store from '@/store';
 import { dashboardStore } from '@/store/dashboards';
 import { serviceStore } from '@/store/services';
 
-import { ConstraintsObj } from '../components/Constraints/ConstraintsBase';
-import { constraintLabels } from '../helpers';
 import {
   Block,
   BlockLink,
@@ -18,31 +15,14 @@ import {
   Limiters,
   Spark,
   SparkConfig,
+  StoredDataPreset,
   SystemStatus,
   UnitAlternatives,
   UserUnits,
 } from '../types';
-import {
-  cleanUnusedNames as cleanUnusedNamesInApi,
-  clearBlocks as clearBlocksInApi,
-  createBlock as createBlockInApi,
-  deleteBlock as deleteBlockInApi,
-  fetchBlock as fetchBlockInApi,
-  fetchBlocks as fetchBlocksInApi,
-  fetchCompatibleTypes as fetchCompatibleTypesInApi,
-  fetchDiscoveredBlocks as fetchDiscoveredBlocksInApi,
-  fetchSystemStatus as fetchSystemStatusInApi,
-  fetchUnitAlternatives as fetchUnitAlternativesInApi,
-  fetchUnits as fetchUnitsInApi,
-  fetchUpdateSource as fetchUpdateSourceInApi,
-  flashFirmware as flashFirmwareInApi,
-  persistBlock as persistBlockInApi,
-  persistUnits as persistUnitsInApi,
-  renameBlock as renameBlockInApi,
-  serviceExport as serviceExportInApi,
-  serviceImport as serviceImportInApi,
-  validateService as validateServiceInApi,
-} from './api';
+import * as api from './api';
+import { calculateBlockLinks, calculateDrivenChains, calculateLimiters } from './helpers';
+import presetsApi from './presets-api';
 
 const rawError = true;
 
@@ -51,99 +31,11 @@ const defaultGroupNames = [
   'Group1', 'Group2', 'Group3', 'Group4', 'Group5', 'Group6', 'Group7',
 ];
 
-const calculateDrivenChains = (blocks: Block[]): string[][] => {
-  const output: string[][] = [];
-
-  const drivenBlocks: { [driven: string]: string[] } = {};
-
-  for (const block of blocks) {
-    Object
-      .values(block.data)
-      .filter((obj: any) => obj instanceof Link && obj.driven && obj.id)
-      .forEach((obj: any) => {
-        const existing = drivenBlocks[obj.id] || [];
-        drivenBlocks[obj.id] = [...existing, block.id];
-      });
-  }
-
-  const generateChains =
-    (chain: string[], latest: string): string[][] => {
-      const additional: string[] = drivenBlocks[latest];
-      if (!additional) {
-        return [[...chain, latest]];
-      }
-      return additional
-        .filter(id => !chain.includes(id))
-        .reduce(
-          (chains: string[][], id: string) => [...chains, ...generateChains([...chain, latest], id)],
-          [],
-        );
-    };
-
-  return Object.keys(drivenBlocks)
-    .reduce((acc, k) => ([...acc, ...generateChains([], k)]), output);
-};
-
-const calculateBlockLinks = (blocks: Block[]): BlockLink[] => {
-  const linkArray: BlockLink[] = [];
-
-  const findRelations =
-    (source: string, relation: string[], val: any): BlockLink[] => {
-      if (val instanceof Link) {
-        if (val.id === null || source === 'DisplaySettings') {
-          return linkArray;
-        }
-        return [{
-          source: source,
-          target: val.toString(),
-          relation: relation,
-        }];
-      }
-      if (val instanceof Object) {
-        return Object.entries(val)
-          .reduce(
-            (acc, child: Record<string, any>) => {
-              if (child[0].startsWith('driven')) {
-                return acc;
-              }
-              return [...acc, ...findRelations(source, [...relation, child[0]], child[1])];
-            },
-            linkArray
-          );
-      }
-      return linkArray;
-    };
-
-  const allLinks: BlockLink[] = [];
-  for (const block of blocks) {
-    allLinks.push(...findRelations(block.id, [], block.data));
-  }
-
-  return allLinks;
-};
-
-const calculateLimiters = (blocks: Block[]): Limiters => {
-  const limited: Limiters = {};
-
-  for (const block of blocks) {
-    const obj: ConstraintsObj = block.data.constrainedBy;
-    if (!obj || obj.constraints.length === 0) {
-      continue;
-    }
-    limited[block.id] = [...obj.constraints]
-      .filter(c => c.limiting)
-      .map(c => Object.keys(c).find(key => key !== 'limiting') || '??')
-      .map(k => constraintLabels.get(k) as string);
-  }
-
-  return limited;
-};
-
 interface SparkServiceState {
-  blocks: Record<string, Block>;
+  blocks: Mapped<Block>;
   units: UserUnits;
   unitAlternatives: UnitAlternatives;
-  compatibleTypes: Record<string, string[]>;
+  compatibleTypes: Mapped<string[]>;
   discoveredBlocks: string[];
   updateSource: EventSource | null;
   lastStatus: SystemStatus | null;
@@ -152,33 +44,42 @@ interface SparkServiceState {
 
 @Module({ store, namespaced: true, dynamic: true, name: 'spark' })
 export class SparkModule extends VuexModule {
-  private services: Record<string, SparkServiceState> = {};
+  private services: Mapped<SparkServiceState> = {};
 
-  public specs: Record<string, BlockSpec> = {};
+  public specs: Mapped<BlockSpec> = {};
+  public presets: Mapped<StoredDataPreset> = {};
 
-  private get allBlockIds(): Record<string, string[]> {
+  private get allBlockIds(): Mapped<string[]> {
     return Object.entries(this.services)
       .reduce((acc, [k, v]) => ({ ...acc, [k]: Object.keys(v.blocks) }), {});
   }
 
-  private get allBlockValues(): Record<string, Block[]> {
+  private get allBlockValues(): Mapped<Block[]> {
     return Object.entries(this.services)
       .reduce((acc, [k, v]) => ({ ...acc, [k]: Object.values(v.blocks) }), {});
   }
 
-  private get allDrivenChains(): Record<string, string[][]> {
+  private get allDrivenChains(): Mapped<string[][]> {
     return Object.keys(this.services)
       .reduce((acc, id) => ({ ...acc, [id]: calculateDrivenChains(this.allBlockValues[id]) }), {});
   }
 
-  private get allBlockLinks(): Record<string, BlockLink[]> {
+  private get allBlockLinks(): Mapped<BlockLink[]> {
     return Object.keys(this.services)
       .reduce((acc, id) => ({ ...acc, [id]: calculateBlockLinks(this.allBlockValues[id]) }), {});
   }
 
-  private get allLimiters(): Record<string, Limiters> {
+  private get allLimiters(): Mapped<Limiters> {
     return Object.keys(this.services)
       .reduce((acc, id) => ({ ...acc, [id]: calculateLimiters(this.allBlockValues[id]) }), {});
+  }
+
+  public get presetIds(): string[] {
+    return Object.keys(this.presets);
+  }
+
+  public get presetValues(): StoredDataPreset[] {
+    return Object.values(this.presets);
   }
 
   public get specIds(): string[] {
@@ -197,7 +98,7 @@ export class SparkModule extends VuexModule {
     return serviceId => !!this.services[serviceId];
   }
 
-  public get blocks(): (serviceId: string) => Record<string, Block> {
+  public get blocks(): (serviceId: string) => Mapped<Block> {
     return serviceId => this.services[serviceId].blocks;
   }
 
@@ -283,7 +184,7 @@ export class SparkModule extends VuexModule {
     return serviceId => this.sparkServiceById(serviceId).config;
   }
 
-  private get allGroupNames(): Record<string, string[]> {
+  private get allGroupNames(): Mapped<string[]> {
     return Object.keys(this.services)
       .reduce(
         (acc, key) => {
@@ -300,6 +201,21 @@ export class SparkModule extends VuexModule {
 
   public get groupNames(): (serviceId: string) => string[] {
     return serviceId => this.allGroupNames[serviceId];
+  }
+
+  @Mutation
+  public commitPreset(preset: StoredDataPreset): void {
+    Vue.set(this.presets, preset.id, preset);
+  }
+
+  @Mutation
+  public commitAllPresets(presets: StoredDataPreset[]): void {
+    Vue.set(this, 'presets', presets.reduce(objReducer('id'), {}));
+  }
+
+  @Mutation
+  public commitRemovePreset(preset: StoredDataPreset): void {
+    Vue.delete(this.presets, preset.id);
   }
 
   @Mutation
@@ -371,6 +287,22 @@ export class SparkModule extends VuexModule {
   }
 
   @Action({ rawError })
+  public async createPreset(preset: StoredDataPreset): Promise<void> {
+    this.commitPreset(await presetsApi.create(preset));
+  }
+
+  @Action({ rawError })
+  public async savePreset(preset: StoredDataPreset): Promise<void> {
+    this.commitPreset(await presetsApi.persist(preset));
+  }
+
+  @Action({ rawError })
+  public async removePreset(preset: StoredDataPreset): Promise<void> {
+    await presetsApi.remove(preset);
+    this.commitRemovePreset(preset);
+  }
+
+  @Action({ rawError })
   public async addService(serviceId: string): Promise<void> {
     if (this.services[serviceId]) {
       throw new Error(`Service ${serviceId} already exists`);
@@ -395,25 +327,25 @@ export class SparkModule extends VuexModule {
 
   @Action({ rawError })
   public async fetchBlock([serviceId, block]: [string, Block]): Promise<void> {
-    const fetched = await fetchBlockInApi(block);
+    const fetched = await api.fetchBlock(block);
     this.commitBlock([serviceId, fetched]);
   }
 
   @Action({ rawError })
   public async createBlock([serviceId, block]: [string, Block]): Promise<void> {
-    const created = await createBlockInApi(block);
+    const created = await api.createBlock(block);
     this.commitBlock([serviceId, created]);
   }
 
   @Action({ rawError })
   public async saveBlock([serviceId, block]: [string, Block]): Promise<void> {
-    const persisted = await persistBlockInApi(block);
+    const persisted = await api.persistBlock(block);
     this.commitBlock([serviceId, persisted]);
   }
 
   @Action({ rawError })
   public async removeBlock([serviceId, block]: [string, Block]): Promise<void> {
-    await deleteBlockInApi(block);
+    await api.deleteBlock(block);
     this.commitRemoveBlock([serviceId, block]);
   }
 
@@ -431,7 +363,7 @@ export class SparkModule extends VuexModule {
 
   @Action({ rawError })
   public async fetchBlocks(serviceId: string): Promise<void> {
-    const blocks = await fetchBlocksInApi(serviceId);
+    const blocks = await api.fetchBlocks(serviceId);
     this.commitAllBlocks([serviceId, blocks]);
   }
 
@@ -440,7 +372,7 @@ export class SparkModule extends VuexModule {
     if (this.blockIds(serviceId).includes(newId)) {
       throw new Error(`Block ${newId} already exists`);
     }
-    await renameBlockInApi(serviceId, currentId, newId);
+    await api.renameBlock(serviceId, currentId, newId);
     await this.fetchBlocks(serviceId);
     dashboardStore.itemValues
       .filter(item => item.config.serviceId === serviceId && item.config.blockId === currentId)
@@ -449,40 +381,40 @@ export class SparkModule extends VuexModule {
 
   @Action({ rawError })
   public async clearBlocks(serviceId: string): Promise<void> {
-    await clearBlocksInApi(serviceId);
+    await api.clearBlocks(serviceId);
     await this.fetchBlocks(serviceId);
   }
 
   @Action({ rawError })
   public async fetchServiceStatus(serviceId: string): Promise<SystemStatus> {
-    const status = await fetchSystemStatusInApi(serviceId);
+    const status = await api.fetchSystemStatus(serviceId);
     this.commitLastStatus([serviceId, status]);
     return status;
   }
 
   @Action({ rawError })
   public async fetchUnits(serviceId: string): Promise<void> {
-    this.commitUnits([serviceId, await fetchUnitsInApi(serviceId)]);
+    this.commitUnits([serviceId, await api.fetchUnits(serviceId)]);
   }
 
   @Action({ rawError })
   public async saveUnits([serviceId, units]: [string, UserUnits]): Promise<void> {
-    this.commitUnits([serviceId, await persistUnitsInApi(serviceId, units)]);
+    this.commitUnits([serviceId, await api.persistUnits(serviceId, units)]);
   }
 
   @Action({ rawError })
   public async fetchUnitAlternatives(serviceId: string): Promise<void> {
-    this.commitUnitAlternatives([serviceId, await fetchUnitAlternativesInApi(serviceId)]);
+    this.commitUnitAlternatives([serviceId, await api.fetchUnitAlternatives(serviceId)]);
   }
 
   @Action({ rawError })
   public async fetchCompatibleTypes(serviceId: string): Promise<void> {
-    this.commitCompatibleTypes([serviceId, await fetchCompatibleTypesInApi(serviceId)]);
+    this.commitCompatibleTypes([serviceId, await api.fetchCompatibleTypes(serviceId)]);
   }
 
   @Action({ rawError })
   public async fetchDiscoveredBlocks(serviceId: string): Promise<void> {
-    const newIds = await fetchDiscoveredBlocksInApi(serviceId);
+    const newIds = await api.fetchDiscoveredBlocks(serviceId);
     this.commitDiscoveredBlocks([serviceId, [...this.services[serviceId].discoveredBlocks, ...newIds]]);
   }
 
@@ -493,12 +425,12 @@ export class SparkModule extends VuexModule {
 
   @Action({ rawError })
   public async cleanUnusedNames(serviceId: string): Promise<string[]> {
-    return await cleanUnusedNamesInApi(serviceId);
+    return await api.cleanUnusedNames(serviceId);
   }
 
   @Action({ rawError })
   public async fetchAll(serviceId: string): Promise<void> {
-    const status = await fetchSystemStatusInApi(serviceId);
+    const status = await api.fetchSystemStatus(serviceId);
     this.commitLastStatus([serviceId, status]);
     if (status.synchronize) {
       await Promise.all([
@@ -513,7 +445,7 @@ export class SparkModule extends VuexModule {
   public async createUpdateSource(serviceId: string): Promise<void> {
     this.commitUpdateSource([
       serviceId,
-      await fetchUpdateSourceInApi(
+      await api.fetchUpdateSource(
         serviceId,
         blocks => {
           this.commitAllBlocks([serviceId, blocks]);
@@ -529,24 +461,42 @@ export class SparkModule extends VuexModule {
 
   @Action({ rawError })
   public async validateService(serviceId: string): Promise<boolean> {
-    return await validateServiceInApi(serviceId);
+    return await api.validateService(serviceId);
   }
 
   @Action({ rawError })
   public async flashFirmware(serviceId: string): Promise<any> {
-    return await flashFirmwareInApi(serviceId);
+    return await api.flashFirmware(serviceId);
   }
 
   @Action({ rawError })
   public async serviceExport(serviceId: string): Promise<any> {
-    return await serviceExportInApi(serviceId);
+    return await api.serviceExport(serviceId);
   }
 
   @Action({ rawError })
   public async serviceImport([serviceId, exported]: [string, any]): Promise<string[]> {
-    const importLog = await serviceImportInApi(serviceId, exported);
+    const importLog = await api.serviceImport(serviceId, exported);
     await this.fetchBlocks(serviceId);
     return importLog;
+  }
+
+  @Action({ rawError })
+  public async setup(): Promise<void> {
+    const onChange = async (preset: StoredDataPreset): Promise<void> => {
+      const existing = this.presets[preset.id];
+      if (!existing || existing._rev !== preset._rev) {
+        this.commitPreset(preset);
+      }
+    };
+    const onDelete = (id: string): void => {
+      const existing = this.presets[id];
+      if (existing) {
+        this.removePreset(existing);
+      }
+    };
+    this.commitAllPresets(await presetsApi.fetch());
+    presetsApi.setup(onChange, onDelete);
   }
 }
 

--- a/src/plugins/spark/store/presets-api.ts
+++ b/src/plugins/spark/store/presets-api.ts
@@ -1,0 +1,7 @@
+import { generate } from '@/helpers/database-api';
+
+import { StoredDataPreset } from '../types';
+
+const api = generate<StoredDataPreset>('spark-presets');
+
+export default api;

--- a/src/plugins/spark/types.ts
+++ b/src/plugins/spark/types.ts
@@ -55,7 +55,7 @@ export interface DataBlock {
   nid?: number;
   type: string;
   groups: number[];
-  data: Mapped<any>;
+  data: any;
 }
 
 export interface Block extends DataBlock {

--- a/src/plugins/spark/types.ts
+++ b/src/plugins/spark/types.ts
@@ -18,6 +18,14 @@ export interface BlockDataPreset {
   generate: BlockDataGenerator;
 }
 
+export interface StoredDataPreset {
+  id: string;
+  type: string;
+  name: string;
+  data: Mapped<any>;
+  _rev?: string;
+}
+
 export interface BlockSpec {
   id: string;
   systemObject?: boolean;
@@ -47,7 +55,7 @@ export interface DataBlock {
   nid?: number;
   type: string;
   groups: number[];
-  data: any;
+  data: Mapped<any>;
 }
 
 export interface Block extends DataBlock {

--- a/src/store/dashboards/api.ts
+++ b/src/store/dashboards/api.ts
@@ -1,44 +1,6 @@
-import database from '@/plugins/database';
+import { generate } from '@/helpers/database-api';
 
 import { Dashboard, DashboardItem } from './types';
 
-const DASHBOARDS = 'dashboards';
-const ITEMS = 'dashboard-items';
-
-export const setupDashboards =
-  (onChanged: (doc: any) => void, onDeleted: (id: string) => void): void =>
-    database.registerModule({ onChanged, onDeleted, id: DASHBOARDS });
-
-export const setupDashboardItems =
-  (onChanged: (doc: any) => void, onDeleted: (id: string) => void): void =>
-    database.registerModule({ onChanged, onDeleted, id: ITEMS });
-
-export const fetchDashboards = async (): Promise<Dashboard[]> =>
-  database.fetchAll(DASHBOARDS);
-
-export const fetchDashboardById = async (id: string): Promise<Dashboard> =>
-  database.fetchById(DASHBOARDS, id);
-
-export const createDashboard = async (dashboard: Dashboard): Promise<Dashboard> =>
-  database.create(DASHBOARDS, dashboard);
-
-export const persistDashboard = async (dashboard: Dashboard): Promise<Dashboard> =>
-  database.persist(DASHBOARDS, dashboard);
-
-export const deleteDashboard = async (dashboard: Dashboard): Promise<Dashboard> =>
-  database.remove(DASHBOARDS, dashboard);
-
-export const fetchDashboardItems = async (): Promise<DashboardItem[]> =>
-  database.fetchAll(ITEMS);
-
-export const fetchDashboardItemById = async (id: string): Promise<DashboardItem> =>
-  database.fetchById(ITEMS, id);
-
-export const persistDashboardItem = async (item: DashboardItem): Promise<DashboardItem> =>
-  database.persist(ITEMS, item);
-
-export const createDashboardItem = async (item: DashboardItem): Promise<DashboardItem> =>
-  database.create(ITEMS, item);
-
-export const deleteDashboardItem = async (item: DashboardItem): Promise<DashboardItem> =>
-  database.remove(ITEMS, item);
+export const dashboardApi = generate<Dashboard>('dashboards');
+export const itemApi = generate<DashboardItem>('dashboard-items');

--- a/src/store/dashboards/index.ts
+++ b/src/store/dashboards/index.ts
@@ -1,21 +1,10 @@
 import Vue from 'vue';
-import { Action, getModule,Module, Mutation, VuexModule } from 'vuex-module-decorators';
+import { Action, getModule, Module, Mutation, VuexModule } from 'vuex-module-decorators';
 
 import { objReducer } from '@/helpers/functional';
 import store from '@/store';
 
-import {
-  createDashboard as createDashboardInApi,
-  createDashboardItem as createDashboardItemInApi,
-  deleteDashboard as removeDashboardInApi,
-  deleteDashboardItem as removeDashboardItemInApi,
-  fetchDashboardItems as fetchDashboardItemsInApi,
-  fetchDashboards as fetchDashboardsInApi,
-  persistDashboard as persistDashboardInApi,
-  persistDashboardItem as persistDashboardItemInApi,
-  setupDashboardItems as setupDashboardItemsInApi,
-  setupDashboards as setupDashboardsInApi,
-} from './api';
+import { dashboardApi, itemApi } from './api';
 import { Dashboard, DashboardItem } from './types';
 export * from './types';
 
@@ -116,12 +105,12 @@ export class DashboardModule extends VuexModule {
 
   @Action({ rawError, commit: 'commitDashboard' })
   public async createDashboard(dashboard: Dashboard): Promise<Dashboard> {
-    return await createDashboardInApi(dashboard);
+    return await dashboardApi.create(dashboard);
   }
 
   @Action({ rawError, commit: 'commitDashboard' })
   public async saveDashboard(dashboard: Dashboard): Promise<Dashboard> {
-    return await persistDashboardInApi(dashboard);
+    return await dashboardApi.persist(dashboard);
   }
 
   @Action({ rawError })
@@ -156,24 +145,24 @@ export class DashboardModule extends VuexModule {
   public async removeDashboard(dashboard: Dashboard): Promise<Dashboard> {
     this.dashboardItemsByDashboardId(dashboard.id)
       .forEach(item => this.context.dispatch('removeDashboardItem', item));
-    await removeDashboardInApi(dashboard).catch(() => { });
+    await dashboardApi.remove(dashboard).catch(() => { });
     return dashboard;
   }
 
   @Action({ rawError, commit: 'commitDashboardItem' })
   public async createDashboardItem(item: DashboardItem): Promise<DashboardItem> {
-    return await createDashboardItemInApi(item);
+    return await itemApi.create(item);
   }
 
   @Action({ rawError, commit: 'commitDashboardItem' })
   public async appendDashboardItem(item: DashboardItem): Promise<DashboardItem> {
     const order = this.dashboardItemsByDashboardId(item.dashboard).length + 1;
-    return await createDashboardItemInApi({ ...item, order });
+    return await itemApi.create({ ...item, order });
   }
 
   @Action({ rawError, commit: 'commitDashboardItem' })
   public async saveDashboardItem(item: DashboardItem): Promise<DashboardItem> {
-    return await persistDashboardItemInApi(item);
+    return await itemApi.persist(item);
   }
 
   @Action({ rawError })
@@ -209,8 +198,7 @@ export class DashboardModule extends VuexModule {
 
   @Action({ rawError, commit: 'commitRemoveDashboardItem' })
   public async removeDashboardItem(item: DashboardItem): Promise<DashboardItem> {
-    await removeDashboardItemInApi(item)
-      .catch(() => { });
+    await itemApi.remove(item).catch(() => { });
     return item;
   }
 
@@ -243,11 +231,11 @@ export class DashboardModule extends VuexModule {
     };
     /* eslint-enable no-underscore-dangle */
 
-    this.commitAllDashboards(await fetchDashboardsInApi());
-    this.commitAllDashboardItems(await fetchDashboardItemsInApi());
+    this.commitAllDashboards(await dashboardApi.fetch());
+    this.commitAllDashboardItems(await itemApi.fetch());
 
-    setupDashboardsInApi(onDashboardChange, onDashboardDelete);
-    setupDashboardItemsInApi(onItemChange, onItemDelete);
+    dashboardApi.setup(onDashboardChange, onDashboardDelete);
+    itemApi.setup(onItemChange, onItemDelete);
   }
 }
 

--- a/src/store/plugins/api.ts
+++ b/src/store/plugins/api.ts
@@ -1,23 +1,6 @@
-import database from '@/plugins/database';
+import { generate } from '@/helpers/database-api';
 import { UIPlugin } from '@/store/plugins';
 
-const PLUGINS = 'plugins';
+const api = generate<UIPlugin>('plugins');
 
-export const setup =
-  (onChanged: (doc: any) => void, onDeleted: (id: string) => void, ): void =>
-    database.registerModule({ onChanged, onDeleted, id: PLUGINS });
-
-export const fetchPlugins = async (): Promise<UIPlugin[]> =>
-  database.fetchAll(PLUGINS);
-
-export const fetchPluginById = async (id: string): Promise<UIPlugin> =>
-  database.fetchById(PLUGINS, id);
-
-export const createPlugin = async (plugin: UIPlugin): Promise<UIPlugin> =>
-  database.create(PLUGINS, plugin);
-
-export const persistPlugin = async (plugin: UIPlugin): Promise<UIPlugin> =>
-  database.persist(PLUGINS, plugin);
-
-export const deletePlugin = async (plugin: UIPlugin): Promise<UIPlugin> =>
-  database.remove(PLUGINS, plugin);
+export default api;

--- a/src/store/plugins/index.ts
+++ b/src/store/plugins/index.ts
@@ -4,13 +4,7 @@ import { Action, getModule, Module, Mutation, VuexModule } from 'vuex-module-dec
 import { objReducer } from '@/helpers/functional';
 import store from '@/store';
 
-import {
-  createPlugin as createPluginInApi,
-  deletePlugin as removePluginInApi,
-  fetchPlugins as fetchPluginsInApi,
-  persistPlugin as persistPluginInApi,
-  setup as setupInApi,
-} from './api';
+import api from './api';
 
 export interface UIPlugin {
   id: string;
@@ -66,30 +60,30 @@ export class PluginModule extends VuexModule {
 
   @Action({ rawError })
   public async fetchPlugins(): Promise<UIPlugin[]> {
-    const plugins = await fetchPluginsInApi();
+    const plugins = await api.fetch();
     this.commitAllPlugins(plugins);
     return plugins;
   }
 
   @Action({ rawError })
   public async createPlugin(plugin: UIPlugin): Promise<void> {
-    this.commitPlugin(await createPluginInApi(plugin));
+    this.commitPlugin(await api.create(plugin));
   }
 
   @Action({ rawError })
   public async savePlugin(plugin: UIPlugin): Promise<void> {
-    this.commitPlugin(await persistPluginInApi(plugin));
+    this.commitPlugin(await api.persist(plugin));
   }
 
   @Action({ rawError })
   public async removePlugin(plugin: UIPlugin): Promise<void> {
-    await removePluginInApi(plugin);
+    await api.remove(plugin);
     this.commitRemovePlugin(plugin);
   }
 
   @Action({ rawError })
   public async setup(): Promise<void> {
-    setupInApi(() => { }, () => { });
+    api.setup(() => { }, () => { });
   }
 }
 

--- a/src/store/services/api.ts
+++ b/src/store/services/api.ts
@@ -1,23 +1,6 @@
-import database from '@/plugins/database';
+import { generate } from '@/helpers/database-api';
 import { Service } from '@/store/services';
 
-const SERVICES = 'services';
+const api = generate<Service>('services');
 
-export const setup =
-  (onChanged: (doc: any) => void, onDeleted: (id: string) => void, ): void =>
-    database.registerModule({ onChanged, onDeleted, id: SERVICES });
-
-export const fetchServices = async (): Promise<Service[]> =>
-  database.fetchAll(SERVICES);
-
-export const fetchServiceById = async (id: string): Promise<Service> =>
-  database.fetchById(SERVICES, id);
-
-export const createService = async (service: Service): Promise<Service> =>
-  database.create(SERVICES, service);
-
-export const persistService = async (service: Service): Promise<Service> =>
-  database.persist(SERVICES, service);
-
-export const deleteService = async (service: Service): Promise<Service> =>
-  database.remove(SERVICES, service);
+export default api;

--- a/src/store/services/index.ts
+++ b/src/store/services/index.ts
@@ -1,17 +1,11 @@
 import Vue from 'vue';
-import { Action, getModule,Module, Mutation, VuexModule } from 'vuex-module-decorators';
+import { Action, getModule, Module, Mutation, VuexModule } from 'vuex-module-decorators';
 
 import { objReducer } from '@/helpers/functional';
 import store from '@/store';
 import { providerStore } from '@/store/providers';
 
-import {
-  createService as createServiceInApi,
-  deleteService as removeServiceInApi,
-  fetchServices as fetchServicesInApi,
-  persistService as persistServiceInApi,
-  setup as setupInApi,
-} from './api';
+import api from './api';
 
 export interface Service {
   id: string;
@@ -80,7 +74,7 @@ export class ServiceModule extends VuexModule {
 
   @Action({ rawError })
   public async createService(service: Service): Promise<Service> {
-    const created = await createServiceInApi(service);
+    const created = await api.create(service);
     this.commitService(created);
     await initService(created);
     return created;
@@ -88,27 +82,26 @@ export class ServiceModule extends VuexModule {
 
   @Action({ rawError, commit: 'commitService' })
   public async saveService(service: Service): Promise<Service> {
-    return await persistServiceInApi(service);
+    return await api.persist(service);
   }
 
   @Action({ rawError, commit: 'commitRemoveService' })
   public async removeService(service: Service): Promise<Service> {
     await providerStore.onRemoveById(service.type)(service);
-    return await removeServiceInApi(service);
+    return await api.remove(service);
   }
 
   @Action({ rawError })
   public async updateServiceOrder(ids: string[]): Promise<void> {
     await Promise.all(
       ids.map(async (id, idx) => {
-        const service = await persistServiceInApi({ ...this.services[id], order: idx + 1 });
+        const service = await api.persist({ ...this.services[id], order: idx + 1 });
         this.commitService(service);
       }));
   }
 
   @Action({ rawError })
   public async setup(): Promise<void> {
-    /* eslint-disable no-underscore-dangle */
     const onChange = async (service: Service): Promise<void> => {
       const existing = this.tryServiceById(service.id);
       if (!existing) {
@@ -124,13 +117,12 @@ export class ServiceModule extends VuexModule {
         this.removeService(existing);
       }
     };
-    /* eslint-enable no-underscore-dangle */
 
-    const services = await fetchServicesInApi();
+    const services = await api.fetch();
     this.commitAllServices(services);
     await Promise.all(services.map(initService));
 
-    setupInApi(onChange, onDelete);
+    api.setup(onChange, onDelete);
   }
 }
 


### PR DESCRIPTION
Resolves #927

Creates presets field in spark store, that is saved to the datastore. 
Presets are global to the Spark plugin, and can be used across multiple Spark services.

Refactored database interaction in the API to use more generic generated CRUD functions, to reduce boilerplate.