### PR TITLE
Use typed BlockChange in quick start

### DIFF
--- a/src/plugins/quickstart/Ferment/changes.ts
+++ b/src/plugins/quickstart/Ferment/changes.ts
@@ -17,7 +17,7 @@ import {
   SetpointProfileBlock,
   SetpointSensorPairBlock,
 } from '@/plugins/spark/block-types';
-import { QuickActionsItem } from '@/plugins/spark/features/QuickActions/types';
+import { BlockChange, QuickActionsItem } from '@/plugins/spark/features/QuickActions/types';
 import { sparkStore } from '@/plugins/spark/store';
 import { Block, DigitalState } from '@/plugins/spark/types';
 import { PersistentWidget } from '@/store/dashboards';
@@ -349,7 +349,10 @@ export const defineWidgets = (
               blockId: config.names.fridgeSetpoint,
               data: { settingEnabled: true },
             },
-          ],
+          ] as [
+              BlockChange<SetpointSensorPairBlock>,
+              BlockChange<SetpointSensorPairBlock>,
+            ],
         },
         {
           name: 'Disable control',
@@ -367,7 +370,11 @@ export const defineWidgets = (
               blockId: config.names.fridgeSetpoint,
               data: { settingEnabled: false },
             },
-          ],
+          ] as [
+              BlockChange<SetpointProfileBlock>,
+              BlockChange<SetpointSensorPairBlock>,
+              BlockChange<SetpointSensorPairBlock>,
+            ],
         },
         {
           name: 'Constant fridge temperature',
@@ -384,6 +391,7 @@ export const defineWidgets = (
             {
               blockId: config.names.beerSetpoint,
               data: { settingEnabled: false },
+              confirmed: {},
             },
             {
               blockId: config.names.coolPid,
@@ -391,6 +399,7 @@ export const defineWidgets = (
                 inputId: new Link(config.names.fridgeSetpoint, interfaceTypes.ProcessValue),
                 ...fridgeCoolConfig,
               },
+              confirmed: {},
             },
             {
               blockId: config.names.heatPid,
@@ -398,12 +407,20 @@ export const defineWidgets = (
                 inputId: new Link(config.names.fridgeSetpoint, interfaceTypes.ProcessValue),
                 ...fridgeHeatConfig,
               },
+              confirmed: {},
             },
             {
               blockId: config.names.tempProfile,
               data: { targetId: new Link(config.names.fridgeSetpoint) },
+              confirmed: {},
             },
-          ],
+          ] as [
+              BlockChange<SetpointSensorPairBlock>,
+              BlockChange<SetpointSensorPairBlock>,
+              BlockChange<PidBlock>,
+              BlockChange<PidBlock>,
+              BlockChange<SetpointProfileBlock>,
+            ],
         },
         {
           name: 'Constant beer temperature',
@@ -412,6 +429,7 @@ export const defineWidgets = (
             {
               blockId: config.names.fridgeSetpoint,
               data: { settingEnabled: false },
+              confirmed: {},
             },
             {
               blockId: config.names.beerSetpoint,
@@ -427,6 +445,7 @@ export const defineWidgets = (
                 inputId: new Link(config.names.beerSetpoint, interfaceTypes.ProcessValue),
                 ...beerCoolConfig,
               },
+              confirmed: {},
             },
             {
               blockId: config.names.heatPid,
@@ -434,12 +453,20 @@ export const defineWidgets = (
                 inputId: new Link(config.names.beerSetpoint, interfaceTypes.ProcessValue),
                 ...beerHeatConfig,
               },
+              confirmed: {},
             },
             {
               blockId: config.names.tempProfile,
               data: { targetId: new Link(config.names.beerSetpoint) },
+              confirmed: {},
             },
-          ],
+          ] as [
+              BlockChange<SetpointSensorPairBlock>,
+              BlockChange<SetpointSensorPairBlock>,
+              BlockChange<PidBlock>,
+              BlockChange<PidBlock>,
+              BlockChange<SetpointProfileBlock>,
+            ],
         },
         {
           name: 'Start profile',
@@ -450,7 +477,9 @@ export const defineWidgets = (
               data: { enabled: true, start: 0 },
               confirmed: { start: true },
             },
-          ],
+          ] as [
+              BlockChange<SetpointProfileBlock>,
+            ],
         },
         {
           name: 'Disable profile',
@@ -460,7 +489,9 @@ export const defineWidgets = (
               blockId: config.names.tempProfile,
               data: { enabled: false },
             },
-          ],
+          ] as [
+              BlockChange<SetpointProfileBlock>,
+            ],
         },
       ]),
     },

--- a/src/plugins/quickstart/Glycol/changes.ts
+++ b/src/plugins/quickstart/Glycol/changes.ts
@@ -16,7 +16,7 @@ import {
   SetpointProfileBlock,
   SetpointSensorPairBlock,
 } from '@/plugins/spark/block-types';
-import { QuickActionsItem } from '@/plugins/spark/features/QuickActions/types';
+import { BlockChange, QuickActionsItem } from '@/plugins/spark/features/QuickActions/types';
 import { sparkStore } from '@/plugins/spark/store';
 import { Block, DigitalState } from '@/plugins/spark/types';
 import { PersistentWidget } from '@/store/dashboards';
@@ -379,7 +379,10 @@ export function defineWidgets(config: GlycolConfig, layouts: BuilderLayout[]): P
               blockId: config.names.beerProfile,
               data: { enabled: false },
             },
-          ],
+          ] as [
+              BlockChange<SetpointSensorPairBlock>,
+              BlockChange<SetpointProfileBlock>,
+            ],
         },
         {
           name: 'Constant beer temperature',
@@ -388,6 +391,7 @@ export function defineWidgets(config: GlycolConfig, layouts: BuilderLayout[]): P
             {
               blockId: config.names.beerProfile,
               data: { enabled: false },
+              confirmed: {},
             },
             {
               blockId: config.names.beerSetpoint,
@@ -399,7 +403,10 @@ export function defineWidgets(config: GlycolConfig, layouts: BuilderLayout[]): P
                 storedSetting: true,
               },
             },
-          ],
+          ] as [
+              BlockChange<SetpointProfileBlock>,
+              BlockChange<SetpointSensorPairBlock>,
+            ],
         },
         {
           name: 'Follow temperature profile',
@@ -407,14 +414,18 @@ export function defineWidgets(config: GlycolConfig, layouts: BuilderLayout[]): P
           changes: [
             {
               blockId: config.names.beerSetpoint,
-              data: { enabled: true },
+              data: { settingEnabled: true },
+              confirmed: {},
             },
             {
               blockId: config.names.beerProfile,
               data: { enabled: true, start: new Date().getTime() / 1000 },
               confirmed: { start: true },
             },
-          ],
+          ] as [
+              BlockChange<SetpointSensorPairBlock>,
+              BlockChange<SetpointProfileBlock>,
+            ],
         },
       ]),
     },

--- a/src/plugins/quickstart/Herms/changes.ts
+++ b/src/plugins/quickstart/Herms/changes.ts
@@ -17,7 +17,7 @@ import {
   PidData,
   SetpointSensorPairBlock,
 } from '@/plugins/spark/block-types';
-import { QuickActionsItem } from '@/plugins/spark/features/QuickActions/types';
+import { BlockChange, QuickActionsItem } from '@/plugins/spark/features/QuickActions/types';
 import { sparkStore } from '@/plugins/spark/store';
 import { AnalogConstraint, Block, DigitalConstraint, DigitalState } from '@/plugins/spark/types';
 import { PersistentWidget } from '@/store/dashboards';
@@ -378,16 +378,23 @@ export function defineWidgets(config: HermsConfig, layouts: BuilderLayout[]): Pe
             {
               blockId: config.names.hltSetpoint,
               data: { settingEnabled: false },
+              confirmed: {},
             },
             {
               blockId: config.names.mtSetpoint,
               data: { settingEnabled: false },
+              confirmed: {},
             },
             {
               blockId: config.names.bkSetpoint,
               data: { settingEnabled: false },
+              confirmed: {},
             },
-          ],
+          ] as [
+              BlockChange<SetpointSensorPairBlock>,
+              BlockChange<SetpointSensorPairBlock>,
+              BlockChange<SetpointSensorPairBlock>,
+            ],
         },
         {
           name: 'Constant HLT Temp',
@@ -396,6 +403,7 @@ export function defineWidgets(config: HermsConfig, layouts: BuilderLayout[]): Pe
             {
               blockId: config.names.mtSetpoint,
               data: { settingEnabled: false },
+              confirmed: {},
             },
             {
               blockId: config.names.hltSetpoint,
@@ -407,7 +415,10 @@ export function defineWidgets(config: HermsConfig, layouts: BuilderLayout[]): Pe
                 storedSetting: true,
               },
             },
-          ],
+          ] as [
+              BlockChange<SetpointSensorPairBlock>,
+              BlockChange<SetpointSensorPairBlock>,
+            ],
         },
         {
           name: 'Constant MT Temp',
@@ -428,8 +439,12 @@ export function defineWidgets(config: HermsConfig, layouts: BuilderLayout[]): Pe
               data: {
                 enabled: true,
               },
+              confirmed: {},
             },
-          ],
+          ] as [
+              BlockChange<SetpointSensorPairBlock>,
+              BlockChange<ActuatorOffsetBlock>,
+            ],
         },
         {
           name: 'Constant BK Temp',
@@ -445,7 +460,9 @@ export function defineWidgets(config: HermsConfig, layouts: BuilderLayout[]): Pe
                 storedSetting: true,
               },
             },
-          ],
+          ] as [
+              BlockChange<SetpointSensorPairBlock>,
+            ],
         },
       ]),
     },

--- a/src/plugins/quickstart/Rims/changes.ts
+++ b/src/plugins/quickstart/Rims/changes.ts
@@ -15,7 +15,7 @@ import {
   PidData,
   SetpointSensorPairBlock,
 } from '@/plugins/spark/block-types';
-import { QuickActionsItem } from '@/plugins/spark/features/QuickActions/types';
+import { BlockChange, QuickActionsItem } from '@/plugins/spark/features/QuickActions/types';
 import { sparkStore } from '@/plugins/spark/store';
 import { Block, DigitalState } from '@/plugins/spark/types';
 import { PersistentWidget } from '@/store/dashboards';
@@ -267,12 +267,17 @@ export function defineWidgets(config: RimsConfig, layouts: BuilderLayout[]): Per
             {
               blockId: config.names.pumpAct,
               data: { desiredState: DigitalState.Active },
+              confirmed: {},
             },
             {
               blockId: config.names.kettleSetpoint,
               data: { settingEnabled: true },
+              confirmed: {},
             },
-          ],
+          ] as [
+              BlockChange<DigitalActuatorBlock>,
+              BlockChange<SetpointSensorPairBlock>,
+            ],
         },
         {
           name: 'Disable pump and heater',
@@ -281,12 +286,17 @@ export function defineWidgets(config: RimsConfig, layouts: BuilderLayout[]): Per
             {
               blockId: config.names.kettleSetpoint,
               data: { settingEnabled: false },
+              confirmed: {},
             },
             {
               blockId: config.names.pumpAct,
               data: { desiredState: DigitalState.Inactive },
+              confirmed: {},
             },
-          ],
+          ] as [
+              BlockChange<SetpointSensorPairBlock>,
+              BlockChange<DigitalActuatorBlock>,
+            ],
         },
         {
           name: 'Enable pump',
@@ -295,8 +305,11 @@ export function defineWidgets(config: RimsConfig, layouts: BuilderLayout[]): Per
             {
               blockId: config.names.pumpAct,
               data: { desiredState: DigitalState.Active },
+              confirmed: {},
             },
-          ],
+          ] as [
+              BlockChange<DigitalActuatorBlock>,
+            ],
         },
         {
           name: 'Disable heater',
@@ -305,8 +318,11 @@ export function defineWidgets(config: RimsConfig, layouts: BuilderLayout[]): Per
             {
               blockId: config.names.kettleSetpoint,
               data: { settingEnabled: false },
+              confirmed: {},
             },
-          ],
+          ] as [
+              BlockChange<SetpointSensorPairBlock>,
+            ],
         },
       ]),
     },

--- a/src/plugins/spark/features/QuickActions/types.d.ts
+++ b/src/plugins/spark/features/QuickActions/types.d.ts
@@ -1,5 +1,7 @@
 import { PersistentWidget } from '@/store/dashboards';
 
+import { Block } from '../../types';
+
 export interface QuickActionsConfig {
   serviceId: string;
   steps: Step[];
@@ -9,11 +11,9 @@ export interface QuickActionsItem extends PersistentWidget {
   config: QuickActionsConfig;
 }
 
-export interface BlockChange {
+export interface BlockChange<BlockT extends Block = Block> {
   blockId: string;
-  data: {
-    [key: string]: any;
-  };
+  data: Partial<BlockT['data']>;
   confirmed: {
     [key: string]: boolean;
   };


### PR DESCRIPTION
Prompted by an `enabled` setting for a Setpoint flying under the radar in the glycol quickstart