### PR TITLE
Move Builder Editor to its own page

### DIFF
--- a/src/components/grid/GridItem.vue
+++ b/src/components/grid/GridItem.vue
@@ -312,9 +312,9 @@ export default class GridItem extends Vue {
 </template>
 
 <style lang="scss" scoped>
-
 .grid-item {
   position: relative;
+  background: $dark;
 }
 
 .grid-item-resize-handle {
@@ -363,6 +363,7 @@ export default class GridItem extends Vue {
 }
 
 .shadowed {
-  text-shadow: 0px 2px 0px $dark, 0px -2px 0px $dark, 2px 0px 0px $dark, -2px 0px 0px $dark;
+  text-shadow: 0px 2px 0px $dark, 0px -2px 0px $dark, 2px 0px 0px $dark,
+    -2px 0px 0px $dark;
 }
 </style>

--- a/src/components/menu/ActionItem.vue
+++ b/src/components/menu/ActionItem.vue
@@ -30,6 +30,7 @@ export default class ActionItem extends Vue {
       clickable: !this.disabled,
       active: this.active && !this.disabled,
       ...this.itemProps,
+      ...this.$attrs,
     };
   }
 

--- a/src/components/sidebar/Navigator.vue
+++ b/src/components/sidebar/Navigator.vue
@@ -1,0 +1,91 @@
+<script lang="ts">
+import Vue from 'vue';
+import { Component, Prop } from 'vue-property-decorator';
+
+import { createDialog } from '@/helpers/dialog';
+
+
+@Component
+export default class Navigator extends Vue {
+
+  // env flag
+  automationFeatureEnabled = !!process.env.BLOX_FEATURE_AUTOMATION;
+
+  @Prop({ type: String, required: false })
+  public readonly activeSection!: string;
+
+  get dense(): boolean {
+    return this.$q.screen.lt.md;
+  }
+
+  get editorDisabled(): boolean {
+    const { ie, edge } = this.$q.platform.is;
+    return Boolean(ie || edge) || this.dense;
+  }
+
+  showWizard(): void {
+    createDialog({
+      parent: this,
+      component: 'WizardDialog',
+    });
+  }
+
+  showAutomationEditor(): void {
+    createDialog({
+      parent: this,
+      component: 'AutomationEditor',
+    });
+  }
+}
+</script>
+
+<template>
+  <div class="col-auto">
+    <ActionItem icon="mdi-home" label="BrewBlox" to="/" exact />
+    <q-separator />
+
+    <div class="row wrap">
+      <q-btn
+        icon="mdi-view-dashboard"
+        label="Dashboards"
+        to="/"
+        :color="activeSection === 'dashboards' ? 'primary' : ''"
+        stack
+        flat
+        class="col-auto q-py-sm"
+        no-caps
+      />
+      <q-btn
+        v-if="!editorDisabled"
+        icon="mdi-tools"
+        label="Builder"
+        to="/builder"
+        :color="activeSection === 'builder' ? 'primary' : ''"
+        stack
+        flat
+        no-caps
+        class="col-auto q-py-sm"
+      />
+      <q-btn
+        icon="mdi-creation"
+        label="Wizardry"
+        stack
+        flat
+        no-caps
+        class="col-auto q-py-sm"
+        @click="showWizard"
+      />
+      <q-btn
+        v-if="automationFeatureEnabled"
+        icon="mdi-calendar-check"
+        label="Automation"
+        stack
+        flat
+        class="col-auto q-py-sm"
+        no-caps
+        @click="showAutomationEditor"
+      />
+    </div>
+    <q-separator />
+  </div>
+</template>

--- a/src/components/toolbar/LayoutHeader.vue
+++ b/src/components/toolbar/LayoutHeader.vue
@@ -1,0 +1,22 @@
+<script lang="ts">
+import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
+
+
+@Component
+export default class LayoutHeader extends Vue {
+
+}
+</script>
+
+<template>
+  <q-header class="glossy bg-dark">
+    <q-toolbar>
+      <q-btn flat dense round icon="menu" @click="$emit('menu')" />
+      <q-toolbar-title>
+        <slot name="title" />
+      </q-toolbar-title>
+      <slot name="buttons" />
+    </q-toolbar>
+  </q-header>
+</template>

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -75,9 +75,6 @@
     overflow: visible
 
 .q-scrollarea
-  height: 100%
-  width: 100%
-
   &__thumb
     opacity: 0.4
     background: white

--- a/src/css/app.sass
+++ b/src/css/app.sass
@@ -12,12 +12,6 @@
 .bg-dark-bright
   background: $dark_bright
 
-.q-page
-  background: $dark_bright
-
-.grid-item
-  background: $dark
-
 .widget-modal
   width: 800px
   height: 800px

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -49,13 +49,6 @@ export default class DefaultLayout extends Vue {
     });
   }
 
-  showBuilderEditor(): void {
-    createDialog({
-      parent: this,
-      component: 'BuilderEditor',
-    });
-  }
-
   showAutomationEditor(): void {
     createDialog({
       parent: this,
@@ -72,17 +65,16 @@ export default class DefaultLayout extends Vue {
 
 <template>
   <q-layout view="lHh Lpr lFf" class="bg-dark-bright">
-    <q-header class="glossy bg-dark">
-      <q-toolbar>
-        <q-btn flat dense round icon="menu" @click="leftDrawerOpen = !leftDrawerOpen" />
-        <q-toolbar-title>
-          <portal-target name="toolbar-title">
-            BrewBlox
-          </portal-target>
-        </q-toolbar-title>
+    <LayoutHeader @menu="leftDrawerOpen = !leftDrawerOpen">
+      <template #title>
+        <portal-target name="toolbar-title">
+          BrewBlox
+        </portal-target>
+      </template>
+      <template #buttons>
         <portal-target name="toolbar-buttons" class="toolbar-buttons" />
-      </q-toolbar>
-    </q-header>
+      </template>
+    </LayoutHeader>
 
     <q-drawer v-model="leftDrawerOpen" content-class="bg-dark" elevated>
       <q-item exact to="/">
@@ -102,7 +94,7 @@ export default class DefaultLayout extends Vue {
 
         <q-separator class="q-mt-sm" />
         <ActionItem icon="mdi-creation" label="Wizardry" @click="showWizard" />
-        <ActionItem v-if="!editorDisabled" icon="mdi-pipe" label="Brewery Builder" @click="showBuilderEditor" />
+        <ActionItem v-if="!editorDisabled" icon="mdi-pipe" label="Brewery Builder" to="/builder" />
         <template v-if="automationFeatureEnabled">
           <ActionItem icon="mdi-calendar-check" label="Automation" @click="showAutomationEditor" />
         </template>

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -15,9 +15,6 @@ export default class DefaultLayout extends Vue {
     checkDatastore();
   }
 
-  // env flag
-  automationFeatureEnabled = !!process.env.BLOX_FEATURE_AUTOMATION;
-
   get version(): string {
     return process.env.BLOX_VERSION || 'UNKNOWN';
   }
@@ -28,11 +25,6 @@ export default class DefaultLayout extends Vue {
 
   get dense(): boolean {
     return this.$q.screen.lt.md;
-  }
-
-  get editorDisabled(): boolean {
-    const { ie, edge } = this.$q.platform.is;
-    return Boolean(ie || edge) || this.dense;
   }
 
   showWizard(): void {
@@ -46,13 +38,6 @@ export default class DefaultLayout extends Vue {
     createDialog({
       parent: this,
       component: 'PluginDialog',
-    });
-  }
-
-  showAutomationEditor(): void {
-    createDialog({
-      parent: this,
-      component: 'AutomationEditor',
     });
   }
 
@@ -77,11 +62,7 @@ export default class DefaultLayout extends Vue {
     </LayoutHeader>
 
     <q-drawer v-model="leftDrawerOpen" content-class="bg-dark column" elevated>
-      <div class="col-auto">
-        <ActionItem to="/" exact icon="mdi-home" label="BrewBlox" />
-        <ActionItem v-if="!editorDisabled" to="/builder" icon="mdi-pipe" label="Brewery Builder" />
-        <q-separator />
-      </div>
+      <Navigator active-section="dashboards" />
 
       <q-scroll-area
         class="col"
@@ -89,12 +70,6 @@ export default class DefaultLayout extends Vue {
       >
         <DashboardIndex v-model="dashboardEditing" />
         <ServiceIndex v-model="serviceEditing" />
-
-        <q-separator class="q-mt-sm" />
-        <ActionItem icon="mdi-creation" label="Wizardry" @click="showWizard" />
-        <template v-if="automationFeatureEnabled">
-          <ActionItem icon="mdi-calendar-check" label="Automation" @click="showAutomationEditor" />
-        </template>
       </q-scroll-area>
 
       <q-item class="col-auto">

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -76,17 +76,15 @@ export default class DefaultLayout extends Vue {
       </template>
     </LayoutHeader>
 
-    <q-drawer v-model="leftDrawerOpen" content-class="bg-dark" elevated>
-      <q-item exact to="/">
-        <q-item-section avatar>
-          <q-icon name="mdi-home" />
-        </q-item-section>
-        <q-item-section>BrewBlox</q-item-section>
-      </q-item>
-      <q-separator />
+    <q-drawer v-model="leftDrawerOpen" content-class="bg-dark column" elevated>
+      <div class="col-auto">
+        <ActionItem to="/" exact icon="mdi-home" label="BrewBlox" />
+        <ActionItem v-if="!editorDisabled" to="/builder" icon="mdi-pipe" label="Brewery Builder" />
+        <q-separator />
+      </div>
 
       <q-scroll-area
-        :style="{height: 'calc(100% - 100px)'}"
+        class="col"
         :thumb-style="{opacity: 0.5, background: 'silver'}"
       >
         <DashboardIndex v-model="dashboardEditing" />
@@ -94,13 +92,12 @@ export default class DefaultLayout extends Vue {
 
         <q-separator class="q-mt-sm" />
         <ActionItem icon="mdi-creation" label="Wizardry" @click="showWizard" />
-        <ActionItem v-if="!editorDisabled" icon="mdi-pipe" label="Brewery Builder" to="/builder" />
         <template v-if="automationFeatureEnabled">
           <ActionItem icon="mdi-calendar-check" label="Automation" @click="showAutomationEditor" />
         </template>
       </q-scroll-area>
 
-      <q-item class="bottomed">
+      <q-item class="col-auto">
         <q-item-section class="col-auto">
           <q-btn flat text-color="white" icon="mdi-puzzle" @click="showPlugins">
             <q-tooltip>
@@ -130,14 +127,9 @@ export default class DefaultLayout extends Vue {
   </q-layout>
 </template>
 
-<style lang="scss">
+<style lang="sass">
 @import "src/css/app.sass";
 
-.bottomed {
-  bottom: 0;
-  position: absolute;
-}
-.q-layout {
-  overflow-x: auto;
-}
+.q-layout
+  overflow-x: auto
 </style>

--- a/src/pages/DashboardPage.vue
+++ b/src/pages/DashboardPage.vue
@@ -154,7 +154,7 @@ export default class DashboardPage extends Vue {
 </script>
 
 <template>
-  <q-page padding>
+  <q-page padding class="bg-dark-bright">
     <q-inner-loading v-if="!dashboard">
       <q-spinner size="50px" color="primary" />
     </q-inner-loading>

--- a/src/pages/ServicePage.vue
+++ b/src/pages/ServicePage.vue
@@ -28,7 +28,7 @@ export default class ServicePage extends Vue {
 </script>
 
 <template>
-  <q-page padding>
+  <q-page padding class="bg-dark-bright">
     <component :is="pageComponent" v-if="serviceValid && pageComponent" :service-id="serviceId" />
     <div v-else-if="serviceValid" class="flex flex-center">
       Invalid service page: {{ serviceId }}

--- a/src/plugins/builder/BuilderCatalog.vue
+++ b/src/plugins/builder/BuilderCatalog.vue
@@ -58,41 +58,42 @@ export default class BuilderCatalog extends DialogBase {
   <q-dialog ref="dialog" @hide="onDialogHide">
     <q-card class="widget-modal">
       <DialogToolbar>Part Catalog</DialogToolbar>
+      <div class="dialog-content column q-pb-md">
+        <q-item class="q-mb-md">
+          <q-item-section>
+            <q-input v-model="partFilter" placeholder="Search Parts" clearable autofocus>
+              <template #append>
+                <q-icon name="search" />
+              </template>
+            </q-input>
+          </q-item-section>
+        </q-item>
 
-      <q-item class="q-mb-md">
-        <q-item-section>
-          <q-input v-model="partFilter" placeholder="Search Parts" clearable autofocus>
-            <template #append>
-              <q-icon name="search" />
-            </template>
-          </q-input>
-        </q-item-section>
-      </q-item>
-
-      <q-scroll-area style="min-height: 400px; height: 60vh;">
-        <q-card-section>
-          <div class="row">
-            <q-item
-              v-for="v in available"
-              :key="v.spec.id"
-              clickable
-              class="col-6"
-              @click="selectPart(v)"
-            >
-              <q-item-section side>
-                <svg
-                  :width="`${SQUARE_SIZE}px`"
-                  :height="`${SQUARE_SIZE}px`"
-                  :viewBox="`0 0 ${partViewBox(v)}`"
-                >
-                  <PartWrapper :part="v.part" />
-                </svg>
-              </q-item-section>
-              <q-item-section>{{ v.spec.title }}</q-item-section>
-            </q-item>
-          </div>
-        </q-card-section>
-      </q-scroll-area>
+        <q-scroll-area class="col">
+          <q-card-section>
+            <div class="row">
+              <q-item
+                v-for="v in available"
+                :key="v.spec.id"
+                clickable
+                class="col-6"
+                @click="selectPart(v)"
+              >
+                <q-item-section side>
+                  <svg
+                    :width="`${SQUARE_SIZE}px`"
+                    :height="`${SQUARE_SIZE}px`"
+                    :viewBox="`0 0 ${partViewBox(v)}`"
+                  >
+                    <PartWrapper :part="v.part" />
+                  </svg>
+                </q-item-section>
+                <q-item-section>{{ v.spec.title }}</q-item-section>
+              </q-item>
+            </div>
+          </q-card-section>
+        </q-scroll-area>
+      </div>
     </q-card>
   </q-dialog>
 </template>

--- a/src/plugins/builder/BuilderEditor.vue
+++ b/src/plugins/builder/BuilderEditor.vue
@@ -198,9 +198,8 @@ export default class BuilderEditor extends Vue {
   get layout(): BuilderLayout | null {
     return builderStore.layoutById(
       this.layoutId
-      || this.initialLayout
-      || builderStore.layoutIds[0]
-      || '');
+      ?? this.$route.params.id
+      ?? builderStore.layoutIds[0]);
   }
 
   get parts(): PersistentPart[] {

--- a/src/plugins/builder/BuilderEditor.vue
+++ b/src/plugins/builder/BuilderEditor.vue
@@ -464,6 +464,10 @@ export default class BuilderEditor extends Vue {
     this.$nextTick(this.setFocus);
   }
 
+  leaveEditor(): void {
+    this.$router.back();
+  }
+
   ////////////////////////////////////////////////////////////////
   // Modes
   ////////////////////////////////////////////////////////////////
@@ -722,7 +726,7 @@ export default class BuilderEditor extends Vue {
   >
     <LayoutHeader @menu="drawerOpen = !drawerOpen">
       <template #title>
-        Brewery Builder Editor
+        Brewery Builder
       </template>
       <template #buttons>
         <div class="row">
@@ -748,30 +752,6 @@ export default class BuilderEditor extends Vue {
             </q-list>
           </q-btn-dropdown>
         </div>
-        <q-btn
-          :disable="!history.length"
-          flat
-          stretch
-          icon="mdi-undo"
-          class="col-auto"
-          @click="undo"
-        >
-          <q-tooltip v-if="history.length">
-            Undo (ctrl-Z)
-          </q-tooltip>
-        </q-btn>
-        <q-btn
-          :disable="!undoneHistory.length"
-          flat
-          stretch
-          icon="mdi-redo"
-          class="col-auto"
-          @click="redo"
-        >
-          <q-tooltip v-if="undoneHistory.length">
-            Redo (ctrl-Y)
-          </q-tooltip>
-        </q-btn>
 
         <LayoutActions
           :layout="layout"
@@ -779,6 +759,8 @@ export default class BuilderEditor extends Vue {
           :save-parts="saveParts"
           stretch
         />
+
+        <q-btn flat stretch icon="mdi-close-circle" size="md" @click="leaveEditor" />
       </template>
     </LayoutHeader>
 
@@ -818,6 +800,31 @@ export default class BuilderEditor extends Vue {
         </q-item>
 
         <ActionItem
+          :disable="!history.length"
+          icon="mdi-undo"
+          label="Undo"
+          :inset-level="0.2"
+          style="min-height: 0px"
+          @click="undo"
+        >
+          <q-item-section side class="text-uppercase">
+            ctrl-Z
+          </q-item-section>
+        </ActionItem>
+        <ActionItem
+          :disable="!undoneHistory.length"
+          icon="mdi-redo"
+          label="Redo"
+          :inset-level="0.2"
+          style="min-height: 0px"
+          @click="redo"
+        >
+          <q-item-section side class="text-uppercase">
+            ctrl-Y
+          </q-item-section>
+        </ActionItem>
+
+        <ActionItem
           v-for="tool in tools"
           :key="'tool-' + tool.value"
           :icon="tool.icon"
@@ -833,7 +840,7 @@ export default class BuilderEditor extends Vue {
 
         <q-item class="q-pb-none">
           <q-item-section class="text-bold">
-            Grid size
+            Editor
           </q-item-section>
         </q-item>
 
@@ -865,12 +872,6 @@ export default class BuilderEditor extends Vue {
               label-always
               @change="v => { layout.height = v; saveLayout() }"
             />
-          </q-item-section>
-        </q-item>
-
-        <q-item class="q-pb-none">
-          <q-item-section class="text-bold">
-            Editor options
           </q-item-section>
         </q-item>
 

--- a/src/plugins/builder/BuilderEditor.vue
+++ b/src/plugins/builder/BuilderEditor.vue
@@ -782,82 +782,91 @@ export default class BuilderEditor extends Vue {
       </template>
     </LayoutHeader>
 
-    <q-drawer v-model="drawerOpen" content-class="bg-dark" elevated>
-      <q-item exact to="/">
-        <q-item-section avatar>
-          <q-icon name="mdi-home" />
-        </q-item-section>
-        <q-item-section>BrewBlox</q-item-section>
-      </q-item>
-      <q-separator />
+    <q-drawer v-model="drawerOpen" content-class="bg-dark column" elevated>
+      <div class="col-auto">
+        <ActionItem to="/" exact icon="mdi-home" label="BrewBlox" />
+        <ActionItem to="/builder" icon="mdi-pipe" label="Brewery Builder" />
+        <q-separator />
+      </div>
 
       <q-scroll-area
         v-if="!!layout"
-        :style="{height: 'calc(100% - 100px)'}"
+        class="col"
         :thumb-style="{opacity: 0.5, background: 'silver'}"
       >
-        <q-expansion-item label="Modes" header-class="text-h6" default-opened>
-          <q-separator inset />
-          <ActionItem
-            v-for="mode in modes"
-            :key="mode.value"
-            :active="currentMode.value === mode.value"
-            :icon="mode.icon"
-            :label="mode.label"
-            no-close
-            @click="currentMode = mode"
-          />
-        </q-expansion-item>
+        <q-item class="q-pb-none">
+          <q-item-section class="text-bold">
+            Modes
+          </q-item-section>
+        </q-item>
 
-        <q-expansion-item label="Tools" header-class="text-h6" default-opened>
-          <q-separator inset />
-          <ActionItem
-            v-for="tool in tools"
-            :key="tool.value"
-            :icon="tool.icon"
-            :label="tool.label"
-            no-close
-            @click="tool.use(findActionParts())"
-          >
-            <q-item-section side class="text-uppercase">
-              {{ tool.shortcut }}
-            </q-item-section>
-          </ActionItem>
-        </q-expansion-item>
+        <ActionItem
+          v-for="mode in modes"
+          :key="'mode-' + mode.value"
+          :active="currentMode.value === mode.value"
+          :icon="mode.icon"
+          :label="mode.label"
+          :inset-level="0.2"
+          style="min-height: 0px"
+          @click="currentMode = mode"
+        />
 
-        <q-expansion-item label="Layout size" header-class="text-h6" default-opened>
-          <q-separator inset />
-          <q-item>
-            <q-item-section>
-              <q-item-label caption>
-                Width
-              </q-item-label>
-              <q-slider
-                :value="layout.width"
-                :min="5"
-                :max="50"
-                label
-                label-always
-                @change="v => { layout.width = v; saveLayout() }"
-              />
-            </q-item-section>
-          </q-item>
-          <q-item>
-            <q-item-section>
-              <q-item-label caption>
-                Height
-              </q-item-label>
-              <q-slider
-                :value="layout.height"
-                :min="5"
-                :max="50"
-                label
-                label-always
-                @change="v => { layout.height = v; saveLayout() }"
-              />
-            </q-item-section>
-          </q-item>
-        </q-expansion-item>
+        <q-item class="q-pb-none">
+          <q-item-section class="text-bold">
+            Tools
+          </q-item-section>
+        </q-item>
+
+        <ActionItem
+          v-for="tool in tools"
+          :key="'tool-' + tool.value"
+          :icon="tool.icon"
+          :label="tool.label"
+          :inset-level="0.2"
+          style="min-height: 0px"
+          @click="tool.use(findActionParts())"
+        >
+          <q-item-section side class="text-uppercase">
+            {{ tool.shortcut }}
+          </q-item-section>
+        </ActionItem>
+
+        <q-item class="q-pb-none">
+          <q-item-section class="text-bold">
+            Layout size
+          </q-item-section>
+        </q-item>
+
+        <q-item :inset-level="0.2">
+          <q-item-section>
+            <q-item-label caption>
+              Width
+            </q-item-label>
+            <q-slider
+              :value="layout.width"
+              :min="5"
+              :max="50"
+              label
+              label-always
+              @change="v => { layout.width = v; saveLayout() }"
+            />
+          </q-item-section>
+        </q-item>
+        <q-item :inset-level="0.2">
+          <q-item-section>
+            <q-item-label caption>
+              Height
+            </q-item-label>
+            <q-slider
+              :value="layout.height"
+              :min="5"
+              :max="50"
+              label
+              label-always
+              @change="v => { layout.height = v; saveLayout() }"
+            />
+          </q-item-section>
+        </q-item>
       </q-scroll-area>
     </q-drawer>
 

--- a/src/plugins/builder/BuilderEditor.vue
+++ b/src/plugins/builder/BuilderEditor.vue
@@ -765,11 +765,7 @@ export default class BuilderEditor extends Vue {
     </LayoutHeader>
 
     <q-drawer v-model="drawerOpen" content-class="bg-dark column" elevated>
-      <div class="col-auto">
-        <ActionItem to="/" exact icon="mdi-home" label="BrewBlox" />
-        <ActionItem to="/builder" icon="mdi-pipe" label="Brewery Builder" />
-        <q-separator />
-      </div>
+      <Navigator active-section="builder" />
 
       <q-scroll-area
         v-if="!!layout"
@@ -800,6 +796,20 @@ export default class BuilderEditor extends Vue {
         </q-item>
 
         <ActionItem
+          v-for="tool in tools"
+          :key="'tool-' + tool.value"
+          :icon="tool.icon"
+          :label="tool.label"
+          :inset-level="0.2"
+          style="min-height: 0px"
+          @click="tool.use(findActionParts())"
+        >
+          <q-item-section side class="text-uppercase">
+            {{ tool.shortcut }}
+          </q-item-section>
+        </ActionItem>
+
+        <ActionItem
           :disable="!history.length"
           icon="mdi-undo"
           label="Undo"
@@ -821,20 +831,6 @@ export default class BuilderEditor extends Vue {
         >
           <q-item-section side class="text-uppercase">
             ctrl-Y
-          </q-item-section>
-        </ActionItem>
-
-        <ActionItem
-          v-for="tool in tools"
-          :key="'tool-' + tool.value"
-          :icon="tool.icon"
-          :label="tool.label"
-          :inset-level="0.2"
-          style="min-height: 0px"
-          @click="tool.use(findActionParts())"
-        >
-          <q-item-section side class="text-uppercase">
-            {{ tool.shortcut }}
           </q-item-section>
         </ActionItem>
 
@@ -881,7 +877,7 @@ export default class BuilderEditor extends Vue {
           :icon="focusWarning
             ? 'mdi-checkbox-marked-outline'
             : 'mdi-checkbox-blank-outline'"
-          label="Show focus warning"
+          label="Dim editor when focus is lost"
           @click="focusWarning = !focusWarning"
         />
       </q-scroll-area>

--- a/src/plugins/builder/BuilderEditor.vue
+++ b/src/plugins/builder/BuilderEditor.vue
@@ -834,7 +834,7 @@ export default class BuilderEditor extends Vue {
 
         <q-item class="q-pb-none">
           <q-item-section class="text-bold">
-            Layout
+            Grid size
           </q-item-section>
         </q-item>
 
@@ -868,6 +868,13 @@ export default class BuilderEditor extends Vue {
             />
           </q-item-section>
         </q-item>
+
+        <q-item class="q-pb-none">
+          <q-item-section class="text-bold">
+            Editor options
+          </q-item-section>
+        </q-item>
+
         <ActionItem
           :active="focusWarning"
           :inset-level="0.2"

--- a/src/plugins/builder/BuilderWidget.vue
+++ b/src/plugins/builder/BuilderWidget.vue
@@ -56,11 +56,10 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
   }
 
   showLayout(layout: BuilderLayout | null): void {
-    const id = layout ? layout.id : null;
-    const currentLayoutId = this.layout?.id === id
-      ? null
-      : id;
-    this.saveConfig({ ...this.config, currentLayoutId });
+    this.saveConfig({
+      ...this.config,
+      currentLayoutId: layout ? layout.id : null,
+    });
   }
 
   selectLayout(layout: BuilderLayout, selected: boolean): void {
@@ -205,7 +204,7 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
 <template>
   <q-card :class="cardClass" :style="builderCardStyle">
     <component :is="toolbarComponent" :crud="crud">
-      <ActionMenu icon="mdi-widgets" :stretch="inDialog">
+      <ActionMenu icon="mdi-file-document-edit" :stretch="inDialog">
         <template #menus>
           <q-list>
             <q-select
@@ -215,7 +214,6 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
               item-aligned
               option-label="title"
               option-value="id"
-              clearable
               @input="v => showLayout(v)"
             >
               <template #option="scope">
@@ -246,7 +244,7 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
               :key="v.id"
               :label="v.title"
               :active="layout && layout.id === v.id"
-              icon="mdi-star"
+              icon="mdi-widgets"
               no-close
               @click="showLayout(v)"
             />

--- a/src/plugins/builder/BuilderWidget.vue
+++ b/src/plugins/builder/BuilderWidget.vue
@@ -204,7 +204,7 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
 <template>
   <q-card :class="cardClass" :style="builderCardStyle">
     <component :is="toolbarComponent" :crud="crud">
-      <ActionMenu icon="mdi-file-document-edit" :stretch="inDialog">
+      <ActionMenu icon="mdi-format-list-bulleted" :stretch="inDialog">
         <template #menus>
           <q-list>
             <q-select
@@ -244,7 +244,6 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
               :key="v.id"
               :label="v.title"
               :active="layout && layout.id === v.id"
-              icon="mdi-widgets"
               no-close
               @click="showLayout(v)"
             />
@@ -252,7 +251,7 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
         </template>
       </ActionMenu>
       <template #actions>
-        <ActionItem v-if="!editorDisabled" icon="mdi-pipe" label="Builder Editor" @click="startEditor" />
+        <ActionItem v-if="!editorDisabled" icon="mdi-tools" label="Edit layout" @click="startEditor" />
       </template>
     </component>
 

--- a/src/plugins/builder/BuilderWidget.vue
+++ b/src/plugins/builder/BuilderWidget.vue
@@ -109,7 +109,7 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
 
   startEditor(): void {
     if (!this.editorDisabled) {
-      this.$router.push('/builder');
+      this.$router.push(`/builder/${this.layout?.id ?? ''}`);
     }
   }
 

--- a/src/plugins/builder/BuilderWidget.vue
+++ b/src/plugins/builder/BuilderWidget.vue
@@ -3,7 +3,6 @@ import { debounce, uid } from 'quasar';
 import { Component, Watch } from 'vue-property-decorator';
 
 import WidgetBase from '@/components/WidgetBase';
-import { createDialog } from '@/helpers/dialog';
 import { spliceById } from '@/helpers/functional';
 
 import { calculateNormalizedFlows } from './calculateFlows';
@@ -21,11 +20,6 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
 
   @Watch('layout')
   watchLayout(): void {
-    this.debouncedCalculate();
-  }
-
-  @Watch('editorActive')
-  watchActive(): void {
     this.debouncedCalculate();
   }
 
@@ -115,16 +109,8 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
 
   startEditor(): void {
     if (!this.editorDisabled) {
-      createDialog({
-        parent: this,
-        component: 'BuilderEditor',
-        initialLayout: this.config.currentLayoutId,
-      });
+      this.$router.push('/builder');
     }
-  }
-
-  get editorActive(): boolean {
-    return builderStore.editorActive;
   }
 
   get gridViewBox(): string {
@@ -185,7 +171,7 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
     builderStore.spec(part).interactHandler?.(part, this.updater);
   }
 
-  onDoubleClick(part: FlowPart): void {
+  edit(part: FlowPart): void {
     if (!this.isClickable(part)) {
       this.startEditor();
     }
@@ -193,9 +179,7 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
 
   async calculate(): Promise<void> {
     await this.$nextTick();
-    if (!this.editorActive) {
-      this.flowParts = calculateNormalizedFlows(this.parts.map(asStatePart));
-    }
+    this.flowParts = calculateNormalizedFlows(this.parts.map(asStatePart));
   }
 
   async migrate(): Promise<void> {
@@ -285,7 +269,7 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
           :transform="`translate(${squares(part.x)}, ${squares(part.y)})`"
           :class="{ pointer: isClickable(part), [part.type]: true }"
           @click="interact(part)"
-          @dblclick.stop="onDoubleClick(part)"
+          @dblclick.stop="edit(part)"
         >
           <PartWrapper :part="part" @update:part="savePart" @dirty="debouncedCalculate" />
         </g>
@@ -293,7 +277,6 @@ export default class BuilderWidget extends WidgetBase<BuilderConfig> {
     </div>
   </q-card>
 </template>
-
 
 <style lang="sass" scoped>
 @import './grid.sass';

--- a/src/plugins/builder/index.ts
+++ b/src/plugins/builder/index.ts
@@ -1,14 +1,11 @@
 import { autoRegister, ref } from '@/helpers/component-ref';
 import { Feature, featureStore } from '@/store/features';
 
-import BuilderEditor from './BuilderEditor.vue';
 import widget from './BuilderWidget.vue';
 import { typeName } from './getters';
 import specs from './specs';
 import { builderStore } from './store';
 import { BuilderConfig } from './types';
-
-ref(BuilderEditor);
 
 const feature: Feature = {
   id: typeName,

--- a/src/plugins/builder/store/index.ts
+++ b/src/plugins/builder/store/index.ts
@@ -22,7 +22,6 @@ const rawError = true;
 export class BuilderModule extends VuexModule {
   private specs: Mapped<PartSpec> = {};
 
-  public editorActive = false;
   public editorMode = '';
   public activeLayoutId: string | null = null;
   public layouts: Mapped<BuilderLayout> = {};
@@ -61,11 +60,6 @@ export class BuilderModule extends VuexModule {
   @Mutation
   public registerPart(spec: PartSpec): void {
     Vue.set(this.specs, spec.id, { ...spec });
-  }
-
-  @Mutation
-  public commitEditorActive(active: boolean): void {
-    this.editorActive = active;
   }
 
   @Mutation

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,6 +6,10 @@ Vue.use(VueRouter);
 const router = new VueRouter({
   routes: [
     {
+      path: '/builder',
+      component: () => import('@/plugins/builder/BuilderEditor.vue'),
+    },
+    {
       path: '/',
       component: () => import('@/layouts/DefaultLayout.vue'),
       children: [

--- a/src/router.ts
+++ b/src/router.ts
@@ -6,7 +6,7 @@ Vue.use(VueRouter);
 const router = new VueRouter({
   routes: [
     {
-      path: '/builder',
+      path: '/builder/:id?',
       component: () => import('@/plugins/builder/BuilderEditor.vue'),
     },
     {


### PR DESCRIPTION
Resolves #1080

- Builder editor is now implemented as page, and not a popup.
- Tools are placed in the sidebar
- Top level index buttons in sidebar to switch between dashboards and builder
- Improved selector in builder widget
- Removed full version of builder widget
- Add option to prevent the "click to resume editing" warning
