### PR TITLE
Warning instead of throwing if flow calc becomes too complex

### DIFF
--- a/src/plugins/builder/FlowSegment.ts
+++ b/src/plugins/builder/FlowSegment.ts
@@ -1,3 +1,5 @@
+import { Notify } from 'quasar';
+
 import { DEFAULT_FRICTION } from './getters';
 import { FlowPart, FlowRoute, PathFriction } from './types';
 
@@ -161,12 +163,13 @@ const mergeEnds = (splits: FlowSegment[]): { splits: FlowSegment[]; end: FlowSeg
         }
       }
       if (unTouchedSplits.length !== 0) {
-        throw (`Calculating current flow path is not supported.
-        Cannot merge friction and pressures of a multi-sink split.`);
+        Notify.create({
+          icon: 'warning',
+          color: 'warning',
+          message: 'The flows split and re-join in too many places. Some flows might be incorrect.',
+        });
       }
-      else {
-        return { splits: combinedSplits, end: end };
-      }
+      return { splits: combinedSplits, end: end };
     }
     if (walker.next) {
       walker = walker.next;

--- a/src/plugins/builder/FlowSegment.ts
+++ b/src/plugins/builder/FlowSegment.ts
@@ -166,7 +166,7 @@ const mergeEnds = (splits: FlowSegment[]): { splits: FlowSegment[]; end: FlowSeg
         Notify.create({
           icon: 'warning',
           color: 'warning',
-          message: 'The flows split and re-join in too many places. Some flows might be incorrect.',
+          message: 'The flows split and rejoin in too many places. Some flows might be incorrect.',
         });
       }
       return { splits: combinedSplits, end: end };


### PR DESCRIPTION
Instead of throwing error and returning no flows at all, skip the difficult flows and continue.
Fixes bug that no parts would render at all, when multiple sources and sinks split and rejoin and our algorithm gives up.