### PR TITLE
Use docker container to create SSL cert

### DIFF
--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -2,4 +2,4 @@ influxdb/
 couchdb/
 dist/*
 !dist/.gitkeep
-traefik/brewblox.*
+traefik/

--- a/dev/makecert.sh
+++ b/dev/makecert.sh
@@ -7,7 +7,7 @@ cd traefik/
 
 if [ ! -f brewblox.key ]; then
 
-  docker run -it --rm \
+  docker run --rm \
     -v "$(pwd)/":/certs/ \
     paulczar/omgwtfssl \
     openssl \

--- a/dev/makecert.sh
+++ b/dev/makecert.sh
@@ -7,15 +7,18 @@ cd traefik/
 
 if [ ! -f brewblox.key ]; then
 
-  docker run \
+  docker run -it --rm \
     -v "$(pwd)/":/certs/ \
-    -e SSL_SUBJECT=localhost \
-    -e SSL_KEY=brewblox.key \
-    -e SSL_CERT=brewblox.crt \
-    -e SSL_EXPIRE=365 \
-    -e SSL_DNS=localhost \
-    -e SILENT=true \
-    paulczar/omgwtfssl
+    paulczar/omgwtfssl \
+    openssl \
+    req \
+    -x509 \
+    -nodes \
+    -days 365 \
+    -newkey rsa:2048 \
+    -subj "/C=NL/ST=./L=./O=Brewblox/OU=./CN=."  \
+    -keyout brewblox.key \
+    -out brewblox.crt
 
   sudo chown "$USER" brewblox.key brewblox.crt
   sudo chmod 644 brewblox.crt


### PR DESCRIPTION
The UI dev environment requires a (self-signed) SSL certificate for HTTPS.
Mac ships with an older / incompatible version of OpenSSL, making cert generation troublesome.

The most elegant solution here is to run OpenSSL containerized.