### PR TITLE
type-only imports (TS 3.8)

### DIFF
--- a/src/components/form/BlockAddressDialog.vue
+++ b/src/components/form/BlockAddressDialog.vue
@@ -7,7 +7,7 @@ import { createBlockDialog } from '@/helpers/dialog';
 import { objectStringSorter } from '@/helpers/functional';
 import { isCompatible } from '@/plugins/spark/block-types';
 import { sparkStore } from '@/plugins/spark/store';
-import { Block, BlockAddress } from '@/plugins/spark/types';
+import type { Block, BlockAddress } from '@/plugins/spark/types';
 import { featureStore } from '@/store/features';
 
 const asAddr = (v: Block | BlockAddress): BlockAddress => ({

--- a/src/components/form/BlockAddressField.vue
+++ b/src/components/form/BlockAddressField.vue
@@ -3,7 +3,7 @@ import { Component, Prop } from 'vue-property-decorator';
 
 import { createBlockDialog, createDialog } from '@/helpers/dialog';
 import { sparkStore } from '@/plugins/spark/store';
-import { Block, BlockAddress } from '@/plugins/spark/types';
+import type { Block, BlockAddress } from '@/plugins/spark/types';
 
 import FieldBase from '../FieldBase';
 

--- a/src/components/form/BlockSelectDialog.vue
+++ b/src/components/form/BlockSelectDialog.vue
@@ -5,7 +5,7 @@ import DialogBase from '@/components/DialogBase';
 import { objectStringSorter } from '@/helpers/functional';
 import { deepCopy } from '@/helpers/units/parseObject';
 import { sparkStore } from '@/plugins/spark/store';
-import { Block } from '@/plugins/spark/types';
+import type { Block } from '@/plugins/spark/types';
 
 @Component
 export default class BlockSelectDialog extends DialogBase {

--- a/src/plugins/spark/block-types.ts
+++ b/src/plugins/spark/block-types.ts
@@ -21,8 +21,8 @@ import { typeName as Spark3Pins } from '@/plugins/spark/features/Spark3Pins/gett
 import { typeName as TempSensorMock } from '@/plugins/spark/features/TempSensorMock/getters';
 import { typeName as TempSensorOneWire } from '@/plugins/spark/features/TempSensorOneWire/getters';
 
-import { Block } from './types';
-export { Block } from './types';
+import type { Block } from './types';
+export type { Block } from './types';
 
 export * from '@/plugins/spark/features/ActuatorAnalogMock/types';
 export * from '@/plugins/spark/features/ActuatorLogic/types';

--- a/src/plugins/spark/components/BlockCrudComponent.ts
+++ b/src/plugins/spark/components/BlockCrudComponent.ts
@@ -9,13 +9,12 @@ import { saveFile } from '@/helpers/import-export';
 import notify from '@/helpers/notify';
 import { postfixedDisplayNames } from '@/helpers/units';
 import { deepCopy } from '@/helpers/units/parseObject';
-import { GraphConfig } from '@/plugins/history/types';
+import type { GraphConfig } from '@/plugins/history/types';
 import { SparkServiceModule, sparkStore } from '@/plugins/spark/store';
-import { BlockConfig, BlockCrud } from '@/plugins/spark/types';
+import type { Block, BlockConfig, BlockCrud } from '@/plugins/spark/types';
 import { dashboardStore } from '@/store/dashboards';
 
 import { blockIdRules, canDisplay, tryDisplayBlock } from '../helpers';
-import { Block } from '../types';
 
 
 @Component

--- a/src/plugins/spark/components/form/AnalogConstraints.vue
+++ b/src/plugins/spark/components/form/AnalogConstraints.vue
@@ -6,7 +6,7 @@ import { createDialog } from '@/helpers/dialog';
 import { Link } from '@/helpers/units';
 import { blockTypes } from '@/plugins/spark/block-types';
 import { analogConstraintLabels } from '@/plugins/spark/getters';
-import { AnalogConstraint, AnalogConstraintKey, AnalogConstraintsObj } from '@/plugins/spark/types';
+import type { AnalogConstraint, AnalogConstraintKey, AnalogConstraintsObj } from '@/plugins/spark/types';
 
 interface Wrapped {
   type: AnalogConstraintKey;

--- a/src/plugins/spark/components/form/DigitalConstraints.vue
+++ b/src/plugins/spark/components/form/DigitalConstraints.vue
@@ -7,7 +7,7 @@ import { Link, Time } from '@/helpers/units';
 import { blockTypes, MutexBlock } from '@/plugins/spark/block-types';
 import { digitalConstraintLabels } from '@/plugins/spark/getters';
 import { sparkStore } from '@/plugins/spark/store';
-import {
+import type {
   DigitalConstraint,
   DigitalConstraintKey,
   DigitalConstraintsObj,

--- a/src/plugins/spark/components/wizard/BlockWizard.vue
+++ b/src/plugins/spark/components/wizard/BlockWizard.vue
@@ -8,7 +8,7 @@ import { objectStringSorter, ruleValidator, suggestId } from '@/helpers/function
 import notify from '@/helpers/notify';
 import { blockIdRules } from '@/plugins/spark/helpers';
 import { SparkServiceModule, sparkStore } from '@/plugins/spark/store';
-import { Block, BlockCrud } from '@/plugins/spark/types';
+import type { Block, BlockCrud } from '@/plugins/spark/types';
 import { Widget } from '@/store/dashboards';
 import { featureStore } from '@/store/features';
 

--- a/src/plugins/spark/features/ActuatorLogic/AnalogCompareEditDialog.vue
+++ b/src/plugins/spark/features/ActuatorLogic/AnalogCompareEditDialog.vue
@@ -8,7 +8,7 @@ import { interfaceTypes, isCompatible } from '@/plugins/spark/block-types';
 import { SparkServiceModule, sparkStore } from '@/plugins/spark/store';
 
 import { analogOpTitles } from './getters';
-import { AnalogCompare } from './types';
+import type { AnalogCompare } from './types';
 
 
 @Component

--- a/src/plugins/spark/features/ActuatorLogic/DigitalCompareEditDialog.vue
+++ b/src/plugins/spark/features/ActuatorLogic/DigitalCompareEditDialog.vue
@@ -5,7 +5,7 @@ import DialogBase from '@/components/DialogBase';
 import { deepCopy } from '@/helpers/units/parseObject';
 
 import { digitalOpTitles } from './getters';
-import { DigitalCompare } from './types';
+import type { DigitalCompare } from './types';
 
 
 @Component

--- a/src/plugins/spark/service/SparkServiceWatcher.vue
+++ b/src/plugins/spark/service/SparkServiceWatcher.vue
@@ -8,7 +8,7 @@ import notify from '@/helpers/notify';
 import { SparkServiceModule, sparkStore } from '@/plugins/spark/store';
 import { systemStore } from '@/store/system';
 
-import { SparkService, SparkStatus } from '../types';
+import type { SparkService, SparkStatus } from '../types';
 
 const snoozeDuration = durationMs('1d');
 const updateValidDuration = durationMs('30s');

--- a/src/plugins/spark/store/index.ts
+++ b/src/plugins/spark/store/index.ts
@@ -3,7 +3,7 @@ import { Action, Module, VuexModule } from 'vuex-class-modules';
 import { extendById, filterById } from '@/helpers/functional';
 import store from '@/store';
 
-import { Block, BlockSpec, StoredDataPreset } from '../types';
+import type { Block, BlockSpec, StoredDataPreset } from '../types';
 import * as api from './api';
 import presetsApi from './presets-api';
 import { SparkServiceModule } from './spark-module';

--- a/src/plugins/spark/store/spark-module.ts
+++ b/src/plugins/spark/store/spark-module.ts
@@ -1,10 +1,11 @@
 import Vue from 'vue';
-import { Action, Module, Mutation, RegisterOptions, VuexModule } from 'vuex-class-modules';
+import { Action, Module, Mutation, VuexModule } from 'vuex-class-modules';
+import type { RegisterOptions } from 'vuex-class-modules';
 
 import { extendById, filterById } from '@/helpers/functional';
 import { deserialize } from '@/helpers/units/parseObject';
 import { EventbusMessage } from '@/plugins/eventbus';
-import {
+import type {
   ApiSparkStatus,
   Block,
   DataBlock,


### PR DESCRIPTION
Silences type import errors in Vue components during npm run serve.
These were caused by TS code going through a babel processor that was unable to handle type imports.