### PR TITLE
Make enter/ctrl-enter behavior more consistent in dialogs.

### DIFF
--- a/src/components/CrudComponent.ts
+++ b/src/components/CrudComponent.ts
@@ -74,7 +74,6 @@ export default class CrudComponent<ConfigT = any> extends Vue {
       message: `Choose a new name for '${widgetTitle}'`,
       value: widgetTitle,
       clearable: false,
-      autogrow: false,
     })
       .onOk(title => this.saveWidget({ ...this.widget, title }));
   }

--- a/src/components/form/BlockAddressDialog.vue
+++ b/src/components/form/BlockAddressDialog.vue
@@ -134,7 +134,7 @@ export default class BlockAddressDialog extends DialogBase {
     ref="dialog"
     no-backdrop-dismiss
     @hide="onDialogHide"
-    @keyup.ctrl.enter="save"
+    @keyup.enter="save"
   >
     <DialogCard v-bind="{title, message, html}">
       <q-select
@@ -143,6 +143,7 @@ export default class BlockAddressDialog extends DialogBase {
         :options="serviceIds"
         label="Service"
         item-aligned
+        @keyup.enter.exact.stop
       />
       <q-select
         v-model="local"
@@ -155,6 +156,7 @@ export default class BlockAddressDialog extends DialogBase {
         item-aligned
         option-label="id"
         option-value="id"
+        @keyup.enter.exact.stop
       >
         <q-tooltip v-if="tooltip">
           {{ tooltip }}

--- a/src/components/form/BlockSelectDialog.vue
+++ b/src/components/form/BlockSelectDialog.vue
@@ -35,6 +35,12 @@ export default class BlockSelectDialog extends DialogBase {
   created(): void {
     this.block = deepCopy(this.value);
   }
+
+  save(): void {
+    if (this.block || this.clearable) {
+      this.onDialogOk(this.block);
+    }
+  }
 }
 </script>
 
@@ -43,7 +49,7 @@ export default class BlockSelectDialog extends DialogBase {
     ref="dialog"
     no-backdrop-dismiss
     @hide="onDialogHide"
-    @keyup.enter="block && onDialogOk(block)"
+    @keyup.enter="save"
   >
     <DialogCard v-bind="{title, message, html}">
       <q-select
@@ -55,6 +61,7 @@ export default class BlockSelectDialog extends DialogBase {
         item-aligned
         option-label="id"
         option-value="id"
+        @keyup.enter.exact.stop
       >
         <template #no-option>
           <q-item>
@@ -71,7 +78,7 @@ export default class BlockSelectDialog extends DialogBase {
           color="primary"
           flat
           label="OK"
-          @click="onDialogOk(block)"
+          @click="save"
         />
       </template>
     </DialogCard>

--- a/src/components/form/ColorDialog.vue
+++ b/src/components/form/ColorDialog.vue
@@ -16,17 +16,26 @@ export default class ColorDialog extends DialogBase {
   created(): void {
     this.local = this.value;
   }
+
+  save(): void {
+    this.onDialogOk(this.local);
+  }
 }
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="onDialogOk(local)">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <q-color v-model="local" format-model="hex" />
       <template #actions>
         <q-btn color="primary" flat label="Cancel" @click="onDialogCancel" />
         <q-btn v-if="clearable" color="primary" flat label="Clear" @click="onDialogOk(null)" />
-        <q-btn color="primary" flat label="OK" @click="onDialogOk(local)" />
+        <q-btn color="primary" flat label="OK" @click="save" />
       </template>
     </DialogCard>
   </q-dialog>

--- a/src/components/form/DatepickerDialog.vue
+++ b/src/components/form/DatepickerDialog.vue
@@ -40,7 +40,12 @@ export default class DatepickerDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <template #body>
         <q-tabs v-model="tab" dense active-color="primary" align="justify" narrow-indicator>

--- a/src/components/form/DatetimeDialog.vue
+++ b/src/components/form/DatetimeDialog.vue
@@ -25,6 +25,10 @@ export default class DatetimeDialog extends DialogBase {
   @Prop({ type: Array, default: () => [] })
   public readonly rules!: InputRule[];
 
+  created(): void {
+    this.setStringVal(this.value);
+  }
+
   get parsed(): Date | null {
     const combined = `${this.dateString} ${this.timeString}`;
     return dateExp.test(combined) && qdate.isValid(combined)
@@ -67,15 +71,16 @@ export default class DatetimeDialog extends DialogBase {
     })
       .onOk(this.setStringVal);
   }
-
-  created(): void {
-    this.setStringVal(this.value);
-  }
 }
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <q-item>
         <q-item-section>

--- a/src/components/form/InputDialog.vue
+++ b/src/components/form/InputDialog.vue
@@ -30,7 +30,7 @@ export default class InputDialog extends DialogBase {
   @Prop({ type: Boolean, default: true })
   public readonly clearable!: boolean;
 
-  @Prop({ type: Boolean, default: true })
+  @Prop({ type: Boolean, default: false })
   public readonly autogrow!: boolean;
 
   @Prop({ type: String, default: '170%' })

--- a/src/components/form/InputField.vue
+++ b/src/components/form/InputField.vue
@@ -21,6 +21,9 @@ export default class InputField extends FieldBase {
   @Prop({ type: Boolean, default: true })
   public readonly clearable!: boolean;
 
+  @Prop({ type: Boolean, default: false })
+  public readonly autogrow!: boolean;
+
   @Emit('input')
   public change(v: string | number): string | number {
     return v;
@@ -55,6 +58,7 @@ export default class InputField extends FieldBase {
       label: this.label,
       rules: this.rules,
       clearable: this.clearable,
+      autogrow: this.autogrow,
     })
       .onOk(this.change);
   }

--- a/src/components/form/LinkDialog.vue
+++ b/src/components/form/LinkDialog.vue
@@ -101,7 +101,7 @@ export default class LinkDialog extends DialogBase {
     ref="dialog"
     no-backdrop-dismiss
     @hide="onDialogHide"
-    @keyup.ctrl.enter="save"
+    @keyup.enter="save"
   >
     <DialogCard v-bind="{title, message, html}">
       <q-select
@@ -114,6 +114,7 @@ export default class LinkDialog extends DialogBase {
         autofocus
         item-aligned
         @input="update"
+        @keyup.enter.exact.stop
       >
         <q-tooltip v-if="tooltip">
           {{ tooltip }}

--- a/src/components/form/SelectDialog.vue
+++ b/src/components/form/SelectDialog.vue
@@ -19,13 +19,30 @@ export default class SelectDialog extends DialogBase {
   created(): void {
     this.local = this.value;
   }
+
+  save(): void {
+    if (this.local !== null || this.selectProps.clearable) {
+      this.onDialogOk(this.local);
+    }
+  }
 }
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="onDialogOk(local)">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
-      <q-select v-model="local" :options="selectOptions" v-bind="selectProps" item-aligned>
+      <q-select
+        v-model="local"
+        :options="selectOptions"
+        v-bind="selectProps"
+        item-aligned
+        @keyup.enter.exact.stop
+      >
         <template #no-option>
           <q-item>
             <q-item-section class="text-grey">
@@ -41,7 +58,7 @@ export default class SelectDialog extends DialogBase {
           color="primary"
           flat
           label="OK"
-          @click="onDialogOk(local)"
+          @click="save"
         />
       </template>
     </DialogCard>

--- a/src/components/form/SliderDialog.vue
+++ b/src/components/form/SliderDialog.vue
@@ -35,7 +35,8 @@ export default class SliderDialog extends DialogBase {
   }
 
   apply(value: number): void {
-    this.onDialogOk(value);
+    this.local = value;
+    this.save();
   }
 
   created(): void {
@@ -45,7 +46,12 @@ export default class SliderDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <q-item>
         <q-item-section class="q-pt-md">

--- a/src/components/form/TagSelectField.vue
+++ b/src/components/form/TagSelectField.vue
@@ -22,7 +22,6 @@ export default class TagSelectField extends FieldBase {
     this.$emit('input', tags);
   }
 
-
   onInput(val, update): void {
     if (val === '') {
       update(() => this.suggestions = []);
@@ -53,6 +52,7 @@ export default class TagSelectField extends FieldBase {
       new-value-mode="add-unique"
       @input="save"
       @filter="onInput"
+      @keyup.enter.stop
     >
       <template #selected-item="scope">
         <q-chip

--- a/src/components/form/TextAreaDialog.vue
+++ b/src/components/form/TextAreaDialog.vue
@@ -30,7 +30,12 @@ export default class TextAreaDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.ctrl.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <q-input
         v-model="local"
@@ -39,6 +44,8 @@ export default class TextAreaDialog extends DialogBase {
         :label="label"
         :autogrow="autogrow"
         autofocus
+        @keyup.enter.exact.stop
+        @keyup.enter.shift.stop
       />
 
       <template #actions>

--- a/src/components/form/TimeUnitDialog.vue
+++ b/src/components/form/TimeUnitDialog.vue
@@ -20,6 +20,10 @@ export default class TimeUnitDialog extends DialogBase {
   @Prop({ type: Array, default: () => [] })
   public readonly rules!: InputRule[];
 
+  created(): void {
+    this.local = unitDurationString(this.value);
+  }
+
   findUnit(s: string): string {
     const match = s.match(/^[0-9\.]*([a-z]*)/i);
     return match && match[1]
@@ -60,16 +64,16 @@ export default class TimeUnitDialog extends DialogBase {
     const val = new Unit(this.localNumber, 'ms');
     this.onDialogOk(val);
   }
-
-  created(): void {
-    this.local = unitDurationString(this.value);
-  }
-
 }
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <q-input
         v-model="local"

--- a/src/components/form/UnitDialog.vue
+++ b/src/components/form/UnitDialog.vue
@@ -31,7 +31,12 @@ export default class UnitDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <q-input
         v-model.number="local"

--- a/src/components/sidebar/PluginDialog.vue
+++ b/src/components/sidebar/PluginDialog.vue
@@ -44,7 +44,12 @@ export default class PluginDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss class="row" @hide="onDialogHide">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    class="row"
+    @hide="onDialogHide"
+  >
     <ActionCardWrapper v-bind="{context}">
       <template #toolbar>
         <DialogToolbar title="UI Plugins" />

--- a/src/components/widget/StoreWidgetDialog.vue
+++ b/src/components/widget/StoreWidgetDialog.vue
@@ -49,7 +49,13 @@ export default class StoreWidgetDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" :maximized="$dense" no-backdrop-dismiss class="row" @hide="onDialogHide">
+  <q-dialog
+    ref="dialog"
+    :maximized="$dense"
+    no-backdrop-dismiss
+    class="row"
+    @hide="onDialogHide"
+  >
     <component
       :is="widgetComponent"
       v-if="!!widget"

--- a/src/components/wizard/WizardDialog.vue
+++ b/src/components/wizard/WizardDialog.vue
@@ -41,7 +41,12 @@ export default class WizardDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" :maximized="$dense" no-backdrop-dismiss @hide="onDialogHide">
+  <q-dialog
+    ref="dialog"
+    :maximized="$dense"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+  >
     <CardWrapper :no-scroll="!!wizardComponent" v-bind="{context}">
       <template #toolbar>
         <DialogToolbar icon="mdi-creation" :title="dialogTitle" />

--- a/src/plugins/automation/components/AutomationCreateDialog.vue
+++ b/src/plugins/automation/components/AutomationCreateDialog.vue
@@ -42,7 +42,7 @@ export default class AutomationCreateDialog extends DialogBase {
     ref="dialog"
     no-backdrop-dismiss
     @hide="onDialogHide"
-    @keyup.ctrl.enter="save"
+    @keyup.enter="save"
   >
     <DialogCard v-bind="{title, message, html}">
       <div

--- a/src/plugins/history/SessionLog/SessionCreateDialog.vue
+++ b/src/plugins/history/SessionLog/SessionCreateDialog.vue
@@ -122,7 +122,12 @@ export default class SessionCreateDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.ctrl.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard :title="title">
       <q-input
         v-model="sessionTitle"

--- a/src/plugins/history/SessionLog/SessionGraphNoteDialog.vue
+++ b/src/plugins/history/SessionLog/SessionGraphNoteDialog.vue
@@ -26,7 +26,12 @@ export default class SessionGraphNoteDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <div class="row q-gutter-xs q-ml-md">
         <DatetimeField

--- a/src/plugins/history/SessionLog/SessionHeaderDialog.vue
+++ b/src/plugins/history/SessionLog/SessionHeaderDialog.vue
@@ -25,7 +25,12 @@ export default class SessionHeaderDialog extends DialogBase {
 
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.ctrl.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard :title="title">
       <InputField
         v-model="session.title"
@@ -43,7 +48,10 @@ export default class SessionHeaderDialog extends DialogBase {
         item-aligned
         @input="v => session.date = v.getTime()"
       />
-      <TagSelectField v-model="session.tags" :existing="knownTags" />
+      <TagSelectField
+        v-model="session.tags"
+        :existing="knownTags"
+      />
       <template #actions>
         <q-btn flat label="Cancel" color="primary" @click="onDialogCancel" />
         <q-btn flat label="OK" color="primary" @click="save" />

--- a/src/plugins/history/SessionLog/SessionLoadDialog.vue
+++ b/src/plugins/history/SessionLog/SessionLoadDialog.vue
@@ -28,7 +28,12 @@ export default class SessionLoadDialog extends DialogBase {
 
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.ctrl.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <SessionSelectField v-model="selected" :sessions="sessions" label="Select session" />
 

--- a/src/plugins/history/SessionLog/SessionSelectField.vue
+++ b/src/plugins/history/SessionLog/SessionSelectField.vue
@@ -76,6 +76,7 @@ export default class SessionSelectField extends FieldBase {
     hide-selected
     placeholder="Search by name or tag"
     @filter="filterFn"
+    @keyup.enter.exact.stop
   >
     <template #option="{opt, selected, toggleOption}">
       <q-item :active="selected" clickable @click="toggleOption(opt)">

--- a/src/plugins/history/SessionLog/SessionTextNoteDialog.vue
+++ b/src/plugins/history/SessionLog/SessionTextNoteDialog.vue
@@ -70,7 +70,12 @@ export default class SessionTextNoteDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.ctrl.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <q-input
         ref="editor"
@@ -80,6 +85,8 @@ export default class SessionTextNoteDialog extends DialogBase {
         autogrow
         autofocus
         item-aligned
+        @keyup.enter.exact.stop
+        @keyup.enter.shift.stop
       />
       <template #actions>
         <q-btn flat label="Insert date" color="primary" @click="insertDate" />

--- a/src/plugins/history/components/GraphDisplayDialog.vue
+++ b/src/plugins/history/components/GraphDisplayDialog.vue
@@ -64,7 +64,12 @@ export default class GraphDisplayDialog extends DialogBase {
 
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <div class="column q-gutter-xs">
         <InputField v-model="rename" title="Label" label="Label" />

--- a/src/plugins/history/components/GraphEditorDialog.vue
+++ b/src/plugins/history/components/GraphEditorDialog.vue
@@ -59,7 +59,12 @@ export default class GraphEditorDialog extends DialogBase {
 
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <CardWrapper no-scroll v-bind="{context}">
       <template #toolbar>
         <DialogToolbar :title="title" />

--- a/src/plugins/history/components/MetricsDisplayDialog.vue
+++ b/src/plugins/history/components/MetricsDisplayDialog.vue
@@ -59,7 +59,12 @@ export default class MetricsDisplayDialog extends DialogBase {
 
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <div class="column q-gutter-xs">
         <InputField v-model="rename" title="Label" label="Label" />

--- a/src/plugins/spark/components/BlockCrudComponent.ts
+++ b/src/plugins/spark/components/BlockCrudComponent.ts
@@ -177,7 +177,6 @@ export default class BlockCrudComponent<BlockT extends Block = Block>
       message: `Choose a new name for '${this.blockId}'`,
       rules: blockIdRules(this.serviceId),
       clearable: false,
-      autogrow: false,
       value: blockId,
     })
       .onOk(async (newId: string) => {

--- a/src/plugins/spark/components/form/ConstraintsDialog.vue
+++ b/src/plugins/spark/components/form/ConstraintsDialog.vue
@@ -28,18 +28,23 @@ export default class ConstraintsDialog extends DialogBase {
   @Prop({ type: String, required: true, validator: v => ['analog', 'digital'].includes(v) })
   public readonly type!: string;
 
-  save(): void {
-    this.onDialogOk(this.local);
-  }
-
   created(): void {
     this.local = deepCopy(this.value);
+  }
+
+  save(): void {
+    this.onDialogOk(this.local);
   }
 }
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <component :is="type" v-model="local" :service-id="serviceId" />
       <template #actions>

--- a/src/plugins/spark/components/form/ConstraintsDialog.vue
+++ b/src/plugins/spark/components/form/ConstraintsDialog.vue
@@ -16,7 +16,7 @@ type ConstraintsObj = AnalogConstraintsObj | DigitalConstraintsObj;
     digital: DigitalConstraints,
   },
 })
-export default class InputDialog extends DialogBase {
+export default class ConstraintsDialog extends DialogBase {
   local: ConstraintsObj | null = null;
 
   @Prop({ type: Object, default: () => ({ constraints: [] }) })

--- a/src/plugins/spark/components/menu/FirmwareUpdateDialog.vue
+++ b/src/plugins/spark/components/menu/FirmwareUpdateDialog.vue
@@ -45,7 +45,7 @@ export default class FirmwareUpdateDialog extends DialogBase {
         : "You're using the latest firmware.";
   }
 
-  get buttonEnabled(): boolean {
+  get ready(): boolean {
     return this.status !== null && this.status.connect;
   }
 
@@ -60,6 +60,9 @@ export default class FirmwareUpdateDialog extends DialogBase {
   }
 
   updateFirmware(): void {
+    if (this.busy || !this.ready) {
+      return;
+    }
     this.busy = true;
     this.error = '';
     this.messages = [];
@@ -73,7 +76,12 @@ export default class FirmwareUpdateDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="updateFirmware"
+  >
     <ActionCardWrapper v-bind="{context}">
       <template #toolbar>
         <DialogToolbar :title="serviceId" subtitle="Firmware update" />
@@ -102,8 +110,8 @@ export default class FirmwareUpdateDialog extends DialogBase {
 
       <template #actions>
         <q-btn
-          :disable="busy || !buttonEnabled"
-          :loading="busy || !buttonEnabled"
+          :disable="busy || !ready"
+          :loading="busy || !ready"
           :color="buttonColor"
           unelevated
           label="Flash"

--- a/src/plugins/spark/components/toolbar/BlockWidgetDialogToolbar.vue
+++ b/src/plugins/spark/components/toolbar/BlockWidgetDialogToolbar.vue
@@ -20,7 +20,12 @@ export default class BlockWidgetDialogToolbar extends BlockCrudComponent {
 </script>
 
 <template>
-  <WidgetDialogToolbar :crud="crud" :mode="mode" @update:mode="updateMode" @title-click="startChangeBlockId">
+  <WidgetDialogToolbar
+    :crud="crud"
+    :mode="mode"
+    @update:mode="updateMode"
+    @title-click="startChangeBlockId"
+  >
     <BlockGraph
       v-if="graphModalOpen"
       :id="`graph-full-toolbar--${widget.id}`"

--- a/src/plugins/spark/components/widget/RelationsDialog.vue
+++ b/src/plugins/spark/components/widget/RelationsDialog.vue
@@ -26,7 +26,12 @@ export default class RelationsDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" maximized no-backdrop-dismiss @hide="onDialogHide">
+  <q-dialog
+    ref="dialog"
+    maximized
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+  >
     <CardWrapper no-scroll v-bind="{context}">
       <template #toolbar>
         <DialogToolbar :title="title" subtitle="Relations diagram" />

--- a/src/plugins/spark/components/wizard/BlockDiscoveryWizard.vue
+++ b/src/plugins/spark/components/wizard/BlockDiscoveryWizard.vue
@@ -67,7 +67,6 @@ export default class BlockDiscoveryWizard
       message: `Choose a new name for '${blockId}'`,
       rules: blockIdRules(serviceId),
       clearable: false,
-      autogrow: false,
       value: blockId,
     })
       .onOk(async (newId: string) => {

--- a/src/plugins/spark/components/wizard/BlockWizardDialog.vue
+++ b/src/plugins/spark/components/wizard/BlockWizardDialog.vue
@@ -17,7 +17,12 @@ export default class BlockWizardDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" :maximized="$dense" no-backdrop-dismiss @hide="onDialogHide">
+  <q-dialog
+    ref="dialog"
+    :maximized="$dense"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+  >
     <CardWrapper no-scroll v-bind="{context}">
       <template #toolbar>
         <DialogToolbar icon="mdi-creation" title="Block wizard" />

--- a/src/plugins/spark/features/ActuatorLogic/AnalogCompareEditDialog.vue
+++ b/src/plugins/spark/features/ActuatorLogic/AnalogCompareEditDialog.vue
@@ -63,7 +63,12 @@ export default class AnalogCompareEditDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <LinkField
         v-model="local.id"
@@ -79,6 +84,7 @@ export default class AnalogCompareEditDialog extends DialogBase {
           emit-value
           label="Operator"
           class="min-width-md col-auto"
+          @keyup.enter.exact.stop
         />
         <UnitField
           v-if="isTemp"

--- a/src/plugins/spark/features/ActuatorLogic/DigitalCompareEditDialog.vue
+++ b/src/plugins/spark/features/ActuatorLogic/DigitalCompareEditDialog.vue
@@ -38,7 +38,7 @@ export default class DigitalCompareEditDialog extends DialogBase {
     ref="dialog"
     no-backdrop-dismiss
     @hide="onDialogHide"
-    @keyup.ctrl.enter="save"
+    @keyup.enter="save"
   >
     <DialogCard v-bind="{title, message, html}">
       <LinkField
@@ -56,6 +56,7 @@ export default class DigitalCompareEditDialog extends DialogBase {
           emit-value
           label="Operator"
           class="min-width-md col-auto"
+          @keyup.enter.exact.stop
         />
         <DigitalStateButton
           v-model="local.rhs"

--- a/src/plugins/spark/features/QuickActions/ChangeConfirmDialog.vue
+++ b/src/plugins/spark/features/QuickActions/ChangeConfirmDialog.vue
@@ -36,7 +36,12 @@ export default class ChangeConfirmDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" no-backdrop-dismiss @hide="onDialogHide" @keyup.enter="save">
+  <q-dialog
+    ref="dialog"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+    @keyup.enter="save"
+  >
     <DialogCard v-bind="{title, message, html}">
       <component
         :is="fieldComponent"

--- a/src/plugins/spark/service/SparkWidgetDialog.vue
+++ b/src/plugins/spark/service/SparkWidgetDialog.vue
@@ -22,7 +22,12 @@ export default class SparkWidgetDialog extends DialogBase {
 </script>
 
 <template>
-  <q-dialog ref="dialog" :maximized="$dense" no-backdrop-dismiss @hide="onDialogHide">
+  <q-dialog
+    ref="dialog"
+    :maximized="$dense"
+    no-backdrop-dismiss
+    @hide="onDialogHide"
+  >
     <SparkWidget :service-id="serviceId" :context="context" />
   </q-dialog>
 </template>


### PR DESCRIPTION
Enter should normally save and close dialogs with a clear single save button.
If there are multiple save buttons (eg. "new", and "save"), it does nothing.
If currently a field is selected that has its own behavior for the enter key,
enter itself is stopped, but ctrl-enter should still save and close the dialog.

If enter by itself can close the dialog, ctrl-enter will also work.

Examples of fields with enter behavior: select dropdowns, and text area fields.

Resolves #1195