### PR TITLE
explicitly import quasar directives

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -56,6 +56,11 @@ module.exports = configure(function (ctx) {
         'SessionStorage',
       ],
 
+      directives: [
+        'ClosePopup',
+        'TouchPan',
+      ],
+
       config: {
         dark: true,
         notify: { message: '', color: 'info' },


### PR DESCRIPTION
Since 1.12, Quasar automatically resolves what components/directives/plugins to use.
Apparently, this does not happen if the directive is used in a render function, such as [here](https://github.com/BrewBlox/brewblox-ui/blob/e8a5f69dca72d2d9201eb960dabd5bb33435871e/src/plugins/history/components/GraphDialog.vue#L59)

Resolves #1375