### PR TITLE
Fix builder highlights on Safari

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -65,3 +65,11 @@ services:
   #     - type: bind
   #       source: ./dev/tilt_share
   #       target: /share
+
+  # hass:
+  #   image: ghcr.io/brewblox/brewblox-hass:develop
+  #   restart: unless-stopped
+  #   volumes:
+  #     - type: bind
+  #       source: ../brewblox-hass/brewblox_hass
+  #       target: /app/brewblox_hass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - traefik.http.services.eventbus.loadbalancer.server.port=15675
 
   victoria:
-    image: victoriametrics/victoria-metrics:v1.69.0
+    image: victoriametrics/victoria-metrics:v1.88.0
     labels:
       - traefik.http.services.victoria.loadbalancer.server.port=8428
     volumes:
@@ -34,7 +34,7 @@ services:
     image: ghcr.io/brewblox/brewblox-history:develop
 
   node-red:
-    image: brewblox/node-red:develop
+    image: ghcr.io/brewblox/node-red:develop
     volumes:
       - type: bind
         source: ${BREWBLOX_CACHE_DIR}/node-red

--- a/src/components/form/ColorField.vue
+++ b/src/components/form/ColorField.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { useField } from '@/composables';
 import { createDialog } from '@/utils/dialog';
-import { computed, defineComponent, PropType } from 'vue';
+import { computed, CSSProperties, defineComponent, PropType } from 'vue';
 
 export default defineComponent({
   name: 'ColorField',
@@ -37,7 +37,7 @@ export default defineComponent({
       !!props.modelValue ? color.value : props.nullText,
     );
 
-    const colorStyle = computed<Mapped<string | undefined>>(() => ({
+    const colorStyle = computed<CSSProperties>(() => ({
       color: color.value,
       backgroundColor: props.modelValue ? color.value : undefined,
       border: `1px ${props.modelValue ? 'solid' : 'dashed'} ${color.value}`,

--- a/src/composables/use-field.ts
+++ b/src/composables/use-field.ts
@@ -1,4 +1,10 @@
-import { computed, ComputedRef, getCurrentInstance, PropType } from 'vue';
+import {
+  computed,
+  ComputedRef,
+  getCurrentInstance,
+  PropType,
+  StyleValue,
+} from 'vue';
 
 export interface UseFieldProps {
   tag: {
@@ -42,7 +48,7 @@ export interface UseFieldProps {
     default: string;
   };
   tagStyle: {
-    type: PropType<string | string[] | AnyDict>;
+    type: PropType<StyleValue>;
     default: string;
   };
   rules: {

--- a/src/plugins/builder/components/BuilderInteraction.vue
+++ b/src/plugins/builder/components/BuilderInteraction.vue
@@ -37,11 +37,16 @@ export default defineComponent({
       computed(() => false),
     );
 
-    const style = computed<CSSProperties>(() =>
-      interactionAllowed.value && props.onInteract != null
-        ? { cursor: 'pointer' }
-        : {},
-    );
+    const style = computed<CSSProperties>(() => {
+      const styleObj: CSSProperties = {};
+
+      if (interactionAllowed.value && props.onInteract != null) {
+        styleObj.cursor = 'pointer';
+        styleObj.pointerEvents = 'auto';
+      }
+
+      return styleObj;
+    });
 
     function interact(): void {
       if (interactionAllowed.value) {
@@ -59,25 +64,22 @@ export default defineComponent({
 </script>
 
 <template>
-  <foreignObject
+  <g
     v-if="!placeholder"
-    v-bind="{ x, y, width, height }"
+    class="interaction"
   >
-    <div
-      class="interaction"
-      :style="style"
-      @click="interact"
-    >
-      <slot />
-    </div>
-  </foreignObject>
+    <rect
+      v-bind="{ x, y, width, height }"
+      class="interaction-highlight"
+    />
+    <foreignObject v-bind="{ x, y, width, height }">
+      <div
+        class="fit"
+        :style="style"
+        @click="interact"
+      >
+        <slot />
+      </div>
+    </foreignObject>
+  </g>
 </template>
-
-<style lang="sass" scoped>
-.interaction
-  opacity: 0
-  border-radius: 4px
-  width: 100%
-  height: 100%
-  position: fixed
-</style>

--- a/src/plugins/builder/components/BuilderInteraction.vue
+++ b/src/plugins/builder/components/BuilderInteraction.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { computed, defineComponent, inject } from 'vue';
+import { computed, CSSProperties, defineComponent, inject } from 'vue';
 import { InteractableKey, PlaceholderKey } from '../symbols';
 
 export default defineComponent({
@@ -37,7 +37,7 @@ export default defineComponent({
       computed(() => false),
     );
 
-    const style = computed(() =>
+    const style = computed<CSSProperties>(() =>
       interactionAllowed.value && props.onInteract != null
         ? { cursor: 'pointer' }
         : {},
@@ -72,3 +72,12 @@ export default defineComponent({
     </div>
   </foreignObject>
 </template>
+
+<style lang="sass" scoped>
+.interaction
+  opacity: 0
+  border-radius: 4px
+  width: 100%
+  height: 100%
+  position: fixed
+</style>

--- a/src/plugins/builder/components/PartWrapper.vue
+++ b/src/plugins/builder/components/PartWrapper.vue
@@ -207,9 +207,11 @@ export default defineComponent({
   fill: none
 
   &:hover
-    .interaction:hover
+    .interaction:hover > .interaction-highlight
       opacity: 0.2
+      fill: white
       background-color: white
+      rx: 4
 
   text
     fill: white

--- a/src/plugins/builder/components/PartWrapper.vue
+++ b/src/plugins/builder/components/PartWrapper.vue
@@ -209,7 +209,6 @@ export default defineComponent({
   &:hover
     .interaction:hover
       opacity: 0.2
-      fill: white
       background-color: white
 
   text
@@ -222,14 +221,6 @@ export default defineComponent({
     line-height: 1
     vertical-align: middle
     display: inline-block
-
-  .interaction
-    pointer-events: auto
-    width: 100%
-    height: 100%
-    opacity: 0
-    rx: 4
-    border-radius: 4px
 
   :not(.interactable) .native-interaction
     pointer-events: none !important


### PR DESCRIPTION
The Safari (WebKit) renderer fails to correctly display opaque HTML elements within an SVG `foreignObject` element.
The HTML element will be rendered without accounting for transformations applied to parent SVG elements.

This can be fixed by making the HTML elements invisible, and delegating hover responses to SVG elements outside the `foreignObject`.

Sibling elements can't both respond to mouse events, even if their rendered position overlaps.
Events are propagated upwards, not sideways. We can account for this by listening for `:hover` events in an element that is a parent to both the clicked element, 
and the element that should display the hovered state (the highlighted element).
The clicked element correctly receives the `click` event because it's a direct descendant.
The highlighted element can be the target of a CSS selector because it's a direct child of (parent) element that receives the `:hover` event.



