### PR TITLE
Fix ui error when input block is linked to DS2408 and print trace in console on error

### DIFF
--- a/src/components/widget/WidgetWrapper.vue
+++ b/src/components/widget/WidgetWrapper.vue
@@ -51,9 +51,8 @@ provide(ContextKey, reactive<WidgetContext>(cloneDeep(props.context)));
 
 provide(InvalidateKey, (reason?: string) => {
   error.value = reason ?? 'Unknown error';
-  error.value += 'widget: ' + props;
   console.error(error.value);
-  invalidateParent(error.value);
+  invalidateParent(reason);
 });
 
 provide(VolatileKey, props.volatile);

--- a/src/components/widget/WidgetWrapper.vue
+++ b/src/components/widget/WidgetWrapper.vue
@@ -51,7 +51,9 @@ provide(ContextKey, reactive<WidgetContext>(cloneDeep(props.context)));
 
 provide(InvalidateKey, (reason?: string) => {
   error.value = reason ?? 'Unknown error';
-  invalidateParent(reason);
+  error.value += 'widget: ' + props;
+  console.error(error.value);
+  invalidateParent(error.value);
 });
 
 provide(VolatileKey, props.volatile);
@@ -60,6 +62,7 @@ provide(ChangeWidgetTitleKey, () => startChangeWidgetTitle(props.widget));
 
 onErrorCaptured((err: Error) => {
   error.value = err.message;
+  console.trace(err);
   return false;
 });
 </script>

--- a/src/components/widget/WidgetWrapper.vue
+++ b/src/components/widget/WidgetWrapper.vue
@@ -51,6 +51,7 @@ provide(ContextKey, reactive<WidgetContext>(cloneDeep(props.context)));
 
 provide(InvalidateKey, (reason?: string) => {
   error.value = reason ?? 'Unknown error';
+  // eslint-disable-next-line no-console
   console.error(error.value);
   invalidateParent(reason);
 });
@@ -61,6 +62,7 @@ provide(ChangeWidgetTitleKey, () => startChangeWidgetTitle(props.widget));
 
 onErrorCaptured((err: Error) => {
   error.value = err.message;
+  // eslint-disable-next-line no-console
   console.trace(err);
   return false;
 });

--- a/src/plugins/builder/components/PartWrapper.vue
+++ b/src/plugins/builder/components/PartWrapper.vue
@@ -112,6 +112,7 @@ onErrorCaptured((err: Error) => {
   error.value = err.message;
   const { type, x, y } = props.part;
   notify.error(`${type} (${x},${y}) :${err.message}`);
+  console.trace(err);
   return false;
 });
 </script>

--- a/src/plugins/builder/components/PartWrapper.vue
+++ b/src/plugins/builder/components/PartWrapper.vue
@@ -112,6 +112,7 @@ onErrorCaptured((err: Error) => {
   error.value = err.message;
   const { type, x, y } = props.part;
   notify.error(`${type} (${x},${y}) :${err.message}`);
+  // eslint-disable-next-line no-console
   console.trace(err);
   return false;
 });

--- a/src/plugins/spark/components/widget/BlockWidgetWrapper.vue
+++ b/src/plugins/spark/components/widget/BlockWidgetWrapper.vue
@@ -74,6 +74,7 @@ watch(
 
 onErrorCaptured((err: Error) => {
   error.value = err.message;
+  console.trace(err);
   return false;
 });
 </script>

--- a/src/plugins/spark/components/widget/BlockWidgetWrapper.vue
+++ b/src/plugins/spark/components/widget/BlockWidgetWrapper.vue
@@ -74,6 +74,7 @@ watch(
 
 onErrorCaptured((err: Error) => {
   error.value = err.message;
+  // eslint-disable-next-line no-console
   console.trace(err);
   return false;
 });

--- a/src/plugins/spark/components/widget/IoArray.vue
+++ b/src/plugins/spark/components/widget/IoArray.vue
@@ -6,6 +6,7 @@ import {
   BlockType,
   ChannelCapabilities,
   DigitalActuatorBlock,
+  DigitalInputBlock,
   DigitalState,
   FastPwmBlock,
   IoArrayInterfaceBlock,
@@ -31,6 +32,7 @@ interface EditableChannel extends IoChannel {
   pwmActuator: FastPwmBlock | null;
   actuatorClaimed: boolean;
   compatibleTypes: BlockOrIntfType[];
+  input: DigitalInputBlock | null;
 }
 
 const sparkStore = useSparkStore();
@@ -46,6 +48,9 @@ const channels = computed<EditableChannel[]>(() =>
     if (c.capabilities & ChannelCapabilities.CHAN_SUPPORTS_PWM_100HZ) {
       compatibleTypes.push(BlockOrIntfType.FastPwm);
     }
+    if (c.capabilities & ChannelCapabilities.CHAN_SUPPORTS_DIGITAL_INPUT) {
+      compatibleTypes.push(BlockOrIntfType.DigitalInput);
+    }
     return {
       ...c,
       compatibleTypes,
@@ -55,7 +60,8 @@ const channels = computed<EditableChannel[]>(() =>
         BlockIntfType.ActuatorDigitalInterface,
       ),
       pwmActuator: ifCompatible(actuator, BlockType.FastPwm),
-      actuatorClaimed: actuator?.data.claimedBy.id != null,
+      actuatorClaimed: actuator?.data.claimedBy?.id != null,
+      input: ifCompatible(actuator, BlockType.DigitalInput),
     };
   }),
 );
@@ -135,6 +141,12 @@ async function updatePwmSetting(channel: EditableChannel): Promise<void> {
             @click="updatePwmSetting(channel)"
           />
         </div>
+        <DigitalStateButton
+          v-else-if="channel.input"
+          disable
+          :model-value="channel.input.data.state"
+          class="col-auto self-center"
+        />
         <div
           v-else
           class="darkened text-italic q-pa-sm"

--- a/src/plugins/spark/features/DS2408/DS2408Widget.vue
+++ b/src/plugins/spark/features/DS2408/DS2408Widget.vue
@@ -35,9 +35,10 @@ function setConnectMode(mode: DS2408ConnectMode): void {
   }
   const linked = sparkStore
     .blocksByService(serviceId)
-    .filter((b): b is DigitalActuatorBlock | MotorValveBlock | DigitalInputBlock =>
-      (isCompatible(b.type, BlockIntfType.ActuatorDigitalInterface)
-      || b.type === BlockType.DigitalInput),
+    .filter(
+      (b): b is DigitalActuatorBlock | MotorValveBlock | DigitalInputBlock =>
+        isCompatible(b.type, BlockIntfType.ActuatorDigitalInterface) ||
+        b.type === BlockType.DigitalInput,
     )
     .filter((b) => b.data.hwDevice.id === block.value.id);
 

--- a/src/plugins/spark/features/DS2408/DS2408Widget.vue
+++ b/src/plugins/spark/features/DS2408/DS2408Widget.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import {
   BlockIntfType,
+  BlockType,
   DigitalActuatorBlock,
+  DigitalInputBlock,
   DS2408Block,
   DS2408ConnectMode,
   MotorValveBlock,
@@ -33,8 +35,9 @@ function setConnectMode(mode: DS2408ConnectMode): void {
   }
   const linked = sparkStore
     .blocksByService(serviceId)
-    .filter((b): b is DigitalActuatorBlock | MotorValveBlock =>
-      isCompatible(b.type, BlockIntfType.ActuatorDigitalInterface),
+    .filter((b): b is DigitalActuatorBlock | MotorValveBlock | DigitalInputBlock =>
+      (isCompatible(b.type, BlockIntfType.ActuatorDigitalInterface)
+      || b.type === BlockType.DigitalInput),
     )
     .filter((b) => b.data.hwDevice.id === block.value.id);
 


### PR DESCRIPTION
DS2408 block failed to render when an input was attached.

Errors were propagated up the stack and lost all context, so only a very generic error was shown: 'something undefined in this block', making it hard to find the cause. By logging the trace in the console, we can find the offending line of code.